### PR TITLE
Add desktop UUID generator

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,16 +1,18 @@
 import { useState, useEffect } from 'react'
-import { 
-  BracketsIcon, 
+import {
+  BracketsIcon,
   Hash,
   Link2Icon,
   ClipboardIcon,
-  Clock
+  Clock,
+  Fingerprint
 } from 'lucide-react'
 import { Sidebar, Tool } from './components/sidebar'
 import { JsonFormatter } from './components/json-formatter'
 import { ToolPlaceholder } from './components/tool-placeholder'
 import { Base64Codec } from './components/base64-codec'
 import { UrlEncoder } from './components/url-encoder'
+import { UuidGenerator } from './components/uuid-generator'
 
 import { ClipboardDetector } from './components/clipboard-detector'
 import { ClipboardDebug } from './components/clipboard-debug'
@@ -24,6 +26,7 @@ const tools: Tool[] = [
   { id: 'json-formatter', name: 'JSON Format/Validate', icon: <BracketsIcon size={16} /> },
   { id: 'base64-string', name: 'Base64 String Encode/Decode', icon: <Hash size={16} /> },
   { id: 'url-encoder', name: 'URL Encoder/Decoder', icon: <Link2Icon size={16} /> },
+  { id: 'uuid-generator', name: 'UUID Generator', icon: <Fingerprint size={16} /> },
   { id: 'speech-length-estimator', name: 'Speech Length Estimator', icon: <Clock size={16} /> },
   { id: 'ethereum-converter', name: 'Ethereum Converter', icon: <Hash size={16} /> },
   { id: 'unit-converter', name: 'Unit Converter', icon: <Hash size={16} /> },
@@ -111,6 +114,8 @@ function App() {
           <Base64Codec className="min-h-full" />
         ) : selectedTool === 'url-encoder' ? (
           <UrlEncoder className="min-h-full" />
+        ) : selectedTool === 'uuid-generator' ? (
+          <UuidGenerator className="min-h-full" />
         ) : selectedTool === 'speech-length-estimator' ? (
           <SpeechLengthEstimator className="min-h-full" />
         ) : selectedTool === 'ethereum-converter' ? (

--- a/desktop/src/components/uuid-generator.tsx
+++ b/desktop/src/components/uuid-generator.tsx
@@ -1,0 +1,330 @@
+import { useState, useEffect } from "react";
+import { AlertCircle, Check, Copy, Fingerprint, RefreshCw } from "lucide-react";
+import {
+  generateUUID,
+  generateMultipleUUIDs,
+  validateUUID,
+  UUIDVersion,
+  UUIDNamespace,
+} from "shared/uuid-generator";
+import { Button } from "./ui/button";
+import { Textarea } from "./ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+
+interface UuidGeneratorProps {
+  className?: string;
+}
+
+export function UuidGenerator({ className = "" }: UuidGeneratorProps) {
+  const [output, setOutput] = useState("");
+  const [count, setCount] = useState<number>(1);
+  const [uuidVersion, setUuidVersion] = useState<UUIDVersion>(UUIDVersion.V4);
+  const [uppercase, setUppercase] = useState(false);
+  const [hyphens, setHyphens] = useState(true);
+  const [namespace, setNamespace] = useState<string>(UUIDNamespace.URL);
+  const [customNamespace, setCustomNamespace] = useState("");
+  const [name, setName] = useState("");
+  const [validateInput, setValidateInput] = useState("");
+  const [validationResult, setValidationResult] = useState<boolean | null>(null);
+  const [mode, setMode] = useState<"generate" | "validate">("generate");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const clipboardContent = localStorage.getItem("clipboard-content-for-tool");
+    if (clipboardContent) {
+      localStorage.removeItem("clipboard-content-for-tool");
+      if (mode === "validate") {
+        setValidateInput(clipboardContent);
+      }
+    }
+  }, []);
+
+  const handleGenerate = () => {
+    try {
+      const options = {
+        version: uuidVersion,
+        uppercase,
+        hyphens,
+        name,
+        namespace,
+        customNamespace,
+      };
+      let result = "";
+      if (count === 1) {
+        result = generateUUID(options);
+      } else {
+        result = generateMultipleUUIDs(count, options).join("\n");
+      }
+      setOutput(result);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+      setOutput("");
+    }
+  };
+
+  const handleValidate = () => {
+    try {
+      if (!validateInput.trim()) {
+        setValidationResult(null);
+        return;
+      }
+      const isValid = validateUUID(validateInput);
+      setValidationResult(isValid);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+      setValidationResult(null);
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(output);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleTabChange = (value: string) => {
+    setMode(value as "generate" | "validate");
+    setError(null);
+    setOutput("");
+    setValidationResult(null);
+  };
+
+  const handleCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value);
+    if (!isNaN(value) && value > 0 && value <= 100) {
+      setCount(value);
+    }
+  };
+
+  const needsNameInput = uuidVersion === UUIDVersion.V5;
+  const needsCustomNamespace = needsNameInput && namespace === UUIDNamespace.CUSTOM;
+
+  return (
+    <div className={`p-4 h-full flex flex-col ${className}`}>
+      <Card className="flex-1 flex flex-col">
+        <CardHeader className="pb-3">
+          <CardTitle>UUID Generator</CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 flex flex-col">
+          <Tabs value={mode} onValueChange={handleTabChange} className="mb-4">
+            <TabsList className="grid grid-cols-2 w-[200px]">
+              <TabsTrigger value="generate">Generate UUIDs</TabsTrigger>
+              <TabsTrigger value="validate">Validate UUID</TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          {mode === "generate" ? (
+            <div className="space-y-4 flex-1 flex flex-col">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 flex-1">
+                <div className="space-y-4">
+                  <div>
+                    <label className="text-sm font-medium">UUID Version</label>
+                    <div className="mt-2 space-y-1">
+                      {Object.values(UUIDVersion).map((ver) => (
+                        <div key={ver} className="flex items-center space-x-2">
+                          <input
+                            type="radio"
+                            id={`uuid-${ver}`}
+                            name="uuid-version"
+                            value={ver}
+                            checked={uuidVersion === ver}
+                            onChange={(e) => setUuidVersion(e.target.value as UUIDVersion)}
+                            className="h-4 w-4"
+                          />
+                          <label htmlFor={`uuid-${ver}`} className="text-sm cursor-pointer capitalize">
+                            {ver}
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  {needsNameInput && (
+                    <div className="space-y-4">
+                      <div>
+                        <label htmlFor="name" className="text-sm font-medium">Name (required for v5)</label>
+                        <input
+                          id="name"
+                          value={name}
+                          onChange={(e) => setName(e.target.value)}
+                          className="mt-1 w-full h-8 px-2 border rounded text-sm"
+                          placeholder="Enter name"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-sm font-medium">Namespace</label>
+                        <div className="mt-2 space-y-1">
+                          {Object.values(UUIDNamespace).map((ns) => (
+                            <div key={ns} className="flex items-center space-x-2">
+                              <input
+                                type="radio"
+                                id={`ns-${ns}`}
+                                name="namespace"
+                                value={ns}
+                                checked={namespace === ns}
+                                onChange={(e) => setNamespace(e.target.value)}
+                                className="h-4 w-4"
+                              />
+                              <label htmlFor={`ns-${ns}`} className="text-sm cursor-pointer capitalize">
+                                {ns === UUIDNamespace.CUSTOM ? "Custom" : ns === UUIDNamespace.URL ? "URL" : "DNS"}
+                              </label>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                      {needsCustomNamespace && (
+                        <div>
+                          <label htmlFor="customNamespace" className="text-sm font-medium">Custom Namespace UUID</label>
+                          <input
+                            id="customNamespace"
+                            value={customNamespace}
+                            onChange={(e) => setCustomNamespace(e.target.value)}
+                            className="mt-1 w-full h-8 px-2 border rounded text-sm"
+                            placeholder="Enter custom namespace UUID"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  <div>
+                    <label htmlFor="count" className="text-sm font-medium">Number of UUIDs</label>
+                    <input
+                      id="count"
+                      type="number"
+                      min="1"
+                      max="100"
+                      value={count}
+                      onChange={handleCountChange}
+                      className="mt-1 w-24 h-8 px-2 border rounded text-sm"
+                    />
+                  </div>
+
+                  <div className="flex items-center space-x-2">
+                    <input
+                      type="checkbox"
+                      id="uppercase"
+                      checked={uppercase}
+                      onChange={(e) => setUppercase(e.target.checked)}
+                      className="h-4 w-4"
+                    />
+                    <label htmlFor="uppercase" className="text-sm cursor-pointer">Uppercase</label>
+                  </div>
+
+                  <div className="flex items-center space-x-2">
+                    <input
+                      type="checkbox"
+                      id="hyphens"
+                      checked={hyphens}
+                      onChange={(e) => setHyphens(e.target.checked)}
+                      className="h-4 w-4"
+                    />
+                    <label htmlFor="hyphens" className="text-sm cursor-pointer">Include hyphens</label>
+                  </div>
+
+                  <Button onClick={handleGenerate} className="w-full flex items-center gap-2">
+                    <RefreshCw className="h-4 w-4" />
+                    Generate UUID{count > 1 ? "s" : ""}
+                  </Button>
+                </div>
+
+                <div className="flex flex-col">
+                  <div className="mb-2 flex justify-between items-center">
+                    <label htmlFor="output" className="text-sm font-medium">
+                      Generated UUID{count > 1 ? "s" : ""}
+                    </label>
+                    {output && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="flex items-center gap-1 h-7 px-2 text-xs"
+                        onClick={handleCopy}
+                      >
+                        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                        {copied ? "Copied!" : "Copy"}
+                      </Button>
+                    )}
+                  </div>
+                  {error ? (
+                    <div className="rounded-md bg-destructive/15 p-3 text-destructive">
+                      <div className="flex items-center gap-2">
+                        <AlertCircle className="h-4 w-4" />
+                        <div className="font-medium">Error</div>
+                      </div>
+                      <div className="mt-2 text-sm">{error}</div>
+                    </div>
+                  ) : (
+                    <Textarea
+                      id="output"
+                      className="flex-1 min-h-[300px] font-mono"
+                      placeholder="Generated UUIDs will appear here..."
+                      value={output}
+                      readOnly
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4 flex-1 flex flex-col">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 flex-1">
+                <div className="flex flex-col">
+                  <label htmlFor="validateInput" className="mb-2 text-sm font-medium">
+                    UUID to Validate
+                  </label>
+                  <Textarea
+                    id="validateInput"
+                    className="min-h-[200px] font-mono flex-1"
+                    placeholder="Enter a UUID to validate..."
+                    value={validateInput}
+                    onChange={(e) => setValidateInput(e.target.value)}
+                  />
+                  <Button onClick={handleValidate} className="w-full mt-4">
+                    Validate UUID
+                  </Button>
+                </div>
+                <div className="flex flex-col">
+                  <label className="text-sm font-medium mb-2">Validation Result</label>
+                  {error ? (
+                    <div className="rounded-md bg-destructive/15 p-3 text-destructive">
+                      <div className="flex items-center gap-2">
+                        <AlertCircle className="h-4 w-4" />
+                        <div className="font-medium">Error</div>
+                      </div>
+                      <div className="mt-2 text-sm">{error}</div>
+                    </div>
+                  ) : validationResult !== null ? (
+                    <div
+                      className={`rounded-md p-3 flex items-center gap-2 ${
+                        validationResult ? "bg-muted" : "bg-destructive/15 text-destructive"
+                      }`}
+                    >
+                      {validationResult ? (
+                        <Check className="h-4 w-4" />
+                      ) : (
+                        <AlertCircle className="h-4 w-4" />
+                      )}
+                      <div className="font-medium">
+                        {validationResult ? "Valid UUID" : "Invalid UUID"}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="text-muted-foreground mt-2">
+                      Enter a UUID above and click Validate to check if it's valid.
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export const UuidIcon = Fingerprint;

--- a/desktop/test/uuid-generator.spec.ts
+++ b/desktop/test/uuid-generator.spec.ts
@@ -1,0 +1,97 @@
+import * as path from 'node:path'
+import {
+  type ElectronApplication,
+  type Page,
+  type JSHandle,
+} from 'playwright'
+import type { BrowserWindow } from 'electron'
+import {
+  beforeAll,
+  afterAll,
+  describe,
+  expect,
+  test,
+} from 'vitest'
+import {
+  launchElectronWithRetry,
+  findButtonByText,
+  takeScreenshot,
+  navigateToTool,
+  waitForComponentTitle,
+  fillTextareaInput,
+} from './utils'
+
+const root = path.join(__dirname, '..')
+let electronApp: ElectronApplication | null = null
+let page: Page | null = null
+
+const TOOL_BUTTON_NAME = 'UUID Generator'
+const COMPONENT_TITLE = 'UUID Generator'
+
+const isCI = process.env.CI === 'true'
+
+describe('UUID Generator tests', async () => {
+  beforeAll(async () => {
+    try {
+      electronApp = await launchElectronWithRetry()
+      page = await electronApp.firstWindow()
+      const loadTimeout = isCI ? 30000 : 10000
+      await page.waitForLoadState('domcontentloaded', { timeout: loadTimeout })
+      const mainWin: JSHandle<BrowserWindow> = await electronApp.browserWindow(page)
+      await mainWin.evaluate(async (win) => {
+        win.webContents.executeJavaScript('// Test initialization complete')
+      })
+    } catch (error) {
+      console.error('Setup failed:', error)
+      throw error
+    }
+  })
+
+  afterAll(async () => {
+    if (page) {
+      await page.close().catch(err => console.error('Error closing page:', err))
+    }
+    if (electronApp) {
+      await electronApp.close().catch(err => console.error('Error closing app:', err))
+    }
+  })
+
+  test('should generate a UUID', async () => {
+    expect(page).not.toBeNull()
+
+    await navigateToTool(page, TOOL_BUTTON_NAME, COMPONENT_TITLE)
+
+    await takeScreenshot(page, 'uuid-generator', 'initial')
+
+    const generateButton = await findButtonByText(page, 'Generate UUID')
+    expect(generateButton).not.toBeNull()
+    await generateButton!.click()
+
+    await page.waitForSelector('textarea', { timeout: isCI ? 10000 : 2000 })
+    const textareas = await page.$$('textarea')
+    expect(textareas.length).toBeGreaterThan(0)
+    const output = await textareas[textareas.length - 1].inputValue()
+    expect(output).not.toBe('')
+    await takeScreenshot(page, 'uuid-generator', 'generated', true)
+  })
+
+  test('should validate UUID correctly', async () => {
+    expect(page).not.toBeNull()
+
+    await navigateToTool(page, TOOL_BUTTON_NAME, COMPONENT_TITLE)
+
+    const validateTab = await findButtonByText(page, 'Validate UUID')
+    if (validateTab) await validateTab.click()
+
+    await page.waitForSelector('textarea', { timeout: isCI ? 10000 : 2000 })
+    await fillTextareaInput(page, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')
+
+    const validateButton = await findButtonByText(page, 'Validate UUID')
+    expect(validateButton).not.toBeNull()
+    await validateButton!.click()
+
+    await page.waitForSelector('text/Valid UUID', { timeout: isCI ? 10000 : 2000 })
+
+    await takeScreenshot(page, 'uuid-generator', 'validated', true)
+  })
+})


### PR DESCRIPTION
## Summary
- implement `UuidGenerator` component in desktop
- add uuid generator to desktop app tools list
- test uuid generator with Playwright

## Testing
- `pnpm run test` *(fails: "Electron launch attempt" messages)*

------
https://chatgpt.com/codex/tasks/task_e_684ab9682f208325ba32e0be3cff4e89