### PR TITLE
refactor clipboard detector registry

### DIFF
--- a/.cursor/rules/shared-feature.mdc
+++ b/.cursor/rules/shared-feature.mdc
@@ -170,30 +170,29 @@ Add the export to `shared/src/index.ts`:
 export * from './feature-name';
 ```
 
-## Step 3.1: Update the Clipboard Detector
+## Step 3.1: Register Clipboard Detection
 
-When adding a new tool, update the clipboard detector so it can suggest your tool when appropriate:
+Each tool can advertise its clipboard capabilities through a small registration file. This keeps the detector decoupled from individual tools and avoids merge conflicts.
 
-1. **Update the Tool Enum**:
-   Add your new tool to the `Tool` enum in `shared/src/clipboard-detector/index.ts`:
+1. **Create a registration file**:
+   Add `clipboard-registration.ts` inside your tool folder (e.g. `shared/src/json-formatter/clipboard-registration.ts`).
+   Export a `ClipboardToolRegistration` object and call `registerClipboardTool`:
 
-   ```
-   export enum Tool {
-     // Existing tools...
-     YOUR_NEW_TOOL = 'your-new-tool'
+   ```ts
+   import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector'
+
+   export const myToolClipboard: ClipboardToolRegistration = {
+     id: Tool.MY_TOOL,
+     supportedTypes: ['string'],
+     detect: (content) => {/* optional detection */}
    }
+
+   registerClipboardTool(myToolClipboard)
    ```
 
-2. **Update Tool Compatibility**:
-   Add your tool to the `TOOL_COMPATIBILITY` configuration in `shared/src/clipboard-detector/index.ts` based on which content types it can handle (string, photo, video).
+2. **Update tests**: add or adjust test cases in `clipboard-detector/index.test.ts` to ensure your tool appears when expected.
 
-3. **Add Content Detection Logic** (if applicable):
-   If your tool handles a specific string format (like JSON or Base64), add appropriate detection logic in the `detectClipboardTools` function.
-
-4. **Update Tests**:
-   Add test cases in `shared/src/clipboard-detector/index.test.ts` to verify your tool is correctly suggested for compatible content types.
-
-This ensures your new tool will be properly suggested to users when they have compatible clipboard content.
+With this plugin style registration, the clipboard detector automatically includes all tools that register themselves.
 
 ## Step 4: Create a Tool Page in Landing Site
 

--- a/shared/src/base64-codec/clipboard-registration.ts
+++ b/shared/src/base64-codec/clipboard-registration.ts
@@ -1,0 +1,25 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+const BASE64_REGEX = /^[A-Za-z0-9+/=]+$/;
+
+function isLikelyBase64(content: string): boolean {
+  if (!content || !BASE64_REGEX.test(content)) {
+    return false;
+  }
+  if (content.length % 4 !== 0) {
+    return false;
+  }
+  if (content.length < 8) {
+    return false;
+  }
+  return true;
+}
+
+export const base64ClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.BASE64_CODEC,
+  supportedTypes: ['string'],
+  detect: isLikelyBase64,
+};
+
+registerClipboardTool(base64ClipboardRegistration);
+

--- a/shared/src/binary-base64-codec/clipboard-registration.ts
+++ b/shared/src/binary-base64-codec/clipboard-registration.ts
@@ -1,0 +1,9 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const binaryBase64ClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.BINARY_BASE64_CODEC,
+  supportedTypes: ['string', 'photo', 'video'],
+};
+
+registerClipboardTool(binaryBase64ClipboardRegistration);
+

--- a/shared/src/clipboard-detector/index.test.ts
+++ b/shared/src/clipboard-detector/index.test.ts
@@ -1,4 +1,5 @@
-import { detectClipboardTools, Tool, ClipboardDetectorOptions } from './index';
+import '../index';
+import { detectClipboardTools, Tool, ClipboardDetectorOptions, getRegisteredTools } from './index';
 import { ClipboardType } from './index';
 
 describe('Clipboard Detector', () => {
@@ -8,9 +9,10 @@ describe('Clipboard Detector', () => {
       const options = {
         type: 'photo' as ClipboardType
       };
+      const expected = getRegisteredTools().filter(r => r.supportedTypes.includes('photo')).length;
       const result = detectClipboardTools(options);
-      
-      expect(result).toHaveLength(3);
+
+      expect(result).toHaveLength(expected);
       expect(result).toContain(Tool.BINARY_BASE64_CODEC);
       expect(result).toContain(Tool.FILE_HASH_COMPARE);
       expect(result).toContain(Tool.FILE_GENERATOR);
@@ -21,9 +23,10 @@ describe('Clipboard Detector', () => {
       const options = {
         type: 'video' as ClipboardType
       };
+      const expected = getRegisteredTools().filter(r => r.supportedTypes.includes('video')).length;
       const result = detectClipboardTools(options);
-      
-      expect(result).toHaveLength(3);
+
+      expect(result).toHaveLength(expected);
       expect(result).toContain(Tool.BINARY_BASE64_CODEC);
       expect(result).toContain(Tool.FILE_HASH_COMPARE);
       expect(result).toContain(Tool.FILE_GENERATOR);
@@ -34,9 +37,10 @@ describe('Clipboard Detector', () => {
       const options = {
         type: 'string' as ClipboardType
       };
+      const expected = getRegisteredTools().filter(r => r.supportedTypes.includes('string')).length;
       const result = detectClipboardTools(options);
-      
-      expect(result).toHaveLength(12);
+
+      expect(result).toHaveLength(expected);
       expect(result).toContain(Tool.BASE64_CODEC);
       expect(result).toContain(Tool.BINARY_BASE64_CODEC);
       expect(result).toContain(Tool.FILE_HASH_COMPARE);
@@ -57,9 +61,10 @@ describe('Clipboard Detector', () => {
         type: 'string' as ClipboardType,
         content: ''
       };
+      const expected = getRegisteredTools().filter(r => r.supportedTypes.includes('string')).length;
       const result = detectClipboardTools(options);
-      
-      expect(result).toHaveLength(12);
+
+      expect(result).toHaveLength(expected);
       expect(result).toContain(Tool.BASE64_CODEC);
       expect(result).toContain(Tool.BINARY_BASE64_CODEC);
       expect(result).toContain(Tool.FILE_HASH_COMPARE);
@@ -241,9 +246,10 @@ describe('Clipboard Detector', () => {
         type: 'string' as ClipboardType,
         content: null as unknown as string
       };
+      const expected = getRegisteredTools().filter(r => r.supportedTypes.includes('string')).length;
       const result = detectClipboardTools(options);
-      
-      expect(result).toHaveLength(12);
+
+      expect(result).toHaveLength(expected);
       expect(result).toContain(Tool.BASE64_CODEC);
       expect(result).toContain(Tool.BINARY_BASE64_CODEC);
       expect(result).toContain(Tool.FILE_HASH_COMPARE);

--- a/shared/src/clipboard-detector/index.ts
+++ b/shared/src/clipboard-detector/index.ts
@@ -31,174 +31,9 @@ export interface ClipboardDetectorOptions {
   content?: string;
 }
 
-/**
- * Tool compatibility configuration
- */
-const TOOL_COMPATIBILITY: Record<ClipboardType, Tool[]> = {
-  'string': [
-    Tool.BASE64_CODEC,
-    Tool.BINARY_BASE64_CODEC,
-    Tool.FILE_HASH_COMPARE,
-    Tool.HTML_TEXT_EXTRACTOR,
-    Tool.JSON_FORMATTER,
-    Tool.TEXT_HASH_GENERATOR,
-    Tool.URL_ENCODER,
-    Tool.FILE_GENERATOR,
-    Tool.UUID_GENERATOR,
-    Tool.SPEECH_LENGTH_ESTIMATOR,
-    Tool.TEXT_TO_SLUG,
-    Tool.ETHEREUM_CONVERTER
-  ],
-  'photo': [
-    Tool.BINARY_BASE64_CODEC,
-    Tool.FILE_HASH_COMPARE,
-    Tool.FILE_GENERATOR
-  ],
-  'video': [
-    Tool.BINARY_BASE64_CODEC,
-    Tool.FILE_HASH_COMPARE,
-    Tool.FILE_GENERATOR
-  ]
-};
+import { getRegisteredTools } from './registry';
+export { registerClipboardTool, getRegisteredTools, type ClipboardToolRegistration } from './registry';
 
-/**
- * JSON detection regex
- */
-const JSON_REGEX = /^\s*(\{|\[)[\s\S]*(\}|\])\s*$/;
-
-/**
- * Base64 detection regex (standard Base64 characters)
- */
-const BASE64_REGEX = /^[A-Za-z0-9+/=]+$/;
-
-/**
- * URL detection regex
- */
-const URL_REGEX = /^(https?:\/\/|www\.)[^\s/$.?#].[^\s]*$/i;
-
-/**
- * Import HTML detection function
- */
-import { isLikelyHtml } from '../html-text-extractor';
-
-/**
- * UUID detection regex
- */
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-/**
- * Ethereum address detection regex
- */
-const ETHEREUM_ADDRESS_REGEX = /^(0x)?[0-9a-f]{40}$/i;
-
-/**
- * Ethereum value detection regex (large numbers that might be Wei values)
- */
-const ETHEREUM_VALUE_REGEX = /^[0-9]{10,78}$/;
-
-/**
- * Checks if a string appears to be a valid UUID
- * @param content - String to check
- * @returns Whether the string appears to be a valid UUID
- */
-function isLikelyUuid(content: string): boolean {
-  return UUID_REGEX.test(content);
-}
-
-/**
- * Checks if a string appears to be related to Ethereum (address or value)
- * @param content - String to check
- * @returns Whether the string appears to be Ethereum-related
- */
-function isLikelyEthereum(content: string): boolean {
-  // Check for Ethereum address
-  if (ETHEREUM_ADDRESS_REGEX.test(content)) {
-    return true;
-  }
-  
-  // Check for large numbers that might be Wei values
-  if (ETHEREUM_VALUE_REGEX.test(content)) {
-    return true;
-  }
-  
-  // Check for common Ethereum unit mentions
-  const lowerContent = content.toLowerCase();
-  if (
-    lowerContent.includes('eth') || 
-    lowerContent.includes('wei') || 
-    lowerContent.includes('gwei') ||
-    lowerContent.includes('ether')
-  ) {
-    return true;
-  }
-  
-  return false;
-}
-
-/**
- * Checks if a string appears to be valid JSON
- * More thorough than just using regex
- * @param content - String to check
- * @returns Whether the string appears to be valid JSON
- */
-function isLikelyJson(content: string): boolean {
-  // Quick initial check with regex
-  if (!JSON_REGEX.test(content)) {
-    return false;
-  }
-  
-  // Try parsing as JSON
-  try {
-    JSON.parse(content);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Checks if a string appears to be valid Base64
- * @param content - String to check
- * @returns Whether the string appears to be valid Base64
- */
-function isLikelyBase64(content: string): boolean {
-  // Must be non-empty and match Base64 character set
-  if (!content || !BASE64_REGEX.test(content)) {
-    return false;
-  }
-  
-  // Must have valid length (divisible by 4)
-  if (content.length % 4 !== 0) {
-    return false;
-  }
-  
-  // Avoid false positives for very short strings
-  if (content.length < 8) {
-    return false;
-  }
-  
-  return true;
-}
-
-/**
- * Checks if a string appears to be a valid URL
- * @param content - String to check
- * @returns Whether the string appears to be a valid URL
- */
-function isLikelyUrl(content: string): boolean {
-  // Basic URL check with regex
-  if (!URL_REGEX.test(content)) {
-    return false;
-  }
-  
-  // Avoid false positives for very short strings
-  if (content.length < 10) {
-    return false;
-  }
-  
-  // Check for common URL components
-  return content.includes('.') && !content.includes(' ');
-}
 
 /**
  * Detect compatible tools based on clipboard content type and content
@@ -206,75 +41,40 @@ function isLikelyUrl(content: string): boolean {
  * @returns Array of compatible tools sorted by relevance
  * @throws Error if clipboardData is null or undefined
  */
-export function detectClipboardTools(clipboardData: { 
-  type: ClipboardType; 
-  content?: string;
+export function detectClipboardTools(clipboardData: {
+  type: ClipboardType;
+  content?: string | null;
 }): Tool[] {
   if (!clipboardData) {
     throw new Error('Failed to detect clipboard tools: Options are required');
   }
 
   const { type, content } = clipboardData;
-  let compatibleTools = [...TOOL_COMPATIBILITY[type] || []];
+  const registrations = getRegisteredTools();
 
-  // For string content, check for special formats and prioritize specific tools
-  if (type === 'string' && content) {
-    // Create a prioritized array of tools based on content detection
-    const prioritizedTools: Tool[] = [];
-    
-    // Add other specialized format tools if they are detected
-    if (isLikelyJson(content)) {
-      prioritizedTools.push(Tool.JSON_FORMATTER);
-    }
-    
-    if (isLikelyHtml(content)) {
-      prioritizedTools.push(Tool.HTML_TEXT_EXTRACTOR);
-    }
-    
-    if (isLikelyUrl(content) && !prioritizedTools.includes(Tool.URL_ENCODER)) {
-      prioritizedTools.push(Tool.URL_ENCODER);
-    }
-    
-    if (isLikelyBase64(content)) {
-      prioritizedTools.push(Tool.BASE64_CODEC);
-    }
-    
-    // Check for UUID format
-    if (isLikelyUuid(content)) {
-      prioritizedTools.push(Tool.UUID_GENERATOR);
-    }
-    
-    // Check for Ethereum-related content
-    if (isLikelyEthereum(content)) {
-      prioritizedTools.push(Tool.ETHEREUM_CONVERTER);
+  const prioritized: Tool[] = [];
+  const general: Tool[] = [];
+  const hasContent = type === 'string' && content !== undefined && content !== null && content !== '';
+
+  for (const reg of registrations) {
+    if (!reg.supportedTypes.includes(type)) {
+      continue;
     }
 
-    // Add the other general tools that weren't specifically matched
-    compatibleTools.forEach(tool => {
-      // Don't duplicate specialized tools that were already matched
-      if (!prioritizedTools.includes(tool)) {
-        // Filter out specialized tools that didn't match the content
-        if (
-          (tool === Tool.JSON_FORMATTER && !isLikelyJson(content)) ||
-          (tool === Tool.HTML_TEXT_EXTRACTOR && !isLikelyHtml(content)) ||
-          (tool === Tool.URL_ENCODER && !isLikelyUrl(content)) ||
-          (tool === Tool.BASE64_CODEC && !isLikelyBase64(content)) ||
-          (tool === Tool.UUID_GENERATOR && !isLikelyUuid(content)) ||
-          (tool === Tool.ETHEREUM_CONVERTER && !isLikelyEthereum(content))
-        ) {
-          // Skip this tool
-        } else {
-          // Include this tool
-          prioritizedTools.push(tool);
-        }
+    if (hasContent && reg.detect) {
+      if (reg.detect(content as string)) {
+        prioritized.push(reg.id);
       }
-    });
-
-    // Always add URL_ENCODER as the first tool for string type
-    prioritizedTools.push(Tool.URL_ENCODER);
-
-    return prioritizedTools;
+    } else {
+      general.push(reg.id);
+    }
   }
 
-  return compatibleTools;
-}                
+  let result = [...new Set([...prioritized, ...general])];
+
+  if (type === 'string' && result.includes(Tool.URL_ENCODER)) {
+    result = [Tool.URL_ENCODER, ...result.filter(t => t !== Tool.URL_ENCODER)];
+  }
+
+  return result;
+}

--- a/shared/src/clipboard-detector/registry.ts
+++ b/shared/src/clipboard-detector/registry.ts
@@ -1,0 +1,29 @@
+import type { ClipboardType, Tool } from './index';
+
+export interface ClipboardToolRegistration {
+  /** Tool identifier */
+  id: Tool;
+  /** Clipboard content types the tool can handle */
+  supportedTypes: ClipboardType[];
+  /** Optional custom detection based on clipboard text */
+  detect?: (content: string) => boolean;
+}
+
+const registry: ClipboardToolRegistration[] = [];
+
+/**
+ * Register a clipboard tool so it can be suggested by the detector
+ * @param registration - Tool registration details
+ */
+export function registerClipboardTool(registration: ClipboardToolRegistration): void {
+  registry.push(registration);
+}
+
+/**
+ * Get all registered clipboard tools
+ * @returns Array of registrations
+ */
+export function getRegisteredTools(): ClipboardToolRegistration[] {
+  return registry;
+}
+

--- a/shared/src/ethereum-converter/clipboard-registration.ts
+++ b/shared/src/ethereum-converter/clipboard-registration.ts
@@ -1,0 +1,24 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+const ETHEREUM_ADDRESS_REGEX = /^(0x)?[0-9a-f]{40}$/i;
+const ETHEREUM_VALUE_REGEX = /^[0-9]{10,78}$/;
+
+function isLikelyEthereum(content: string): boolean {
+  if (ETHEREUM_ADDRESS_REGEX.test(content)) {
+    return true;
+  }
+  if (ETHEREUM_VALUE_REGEX.test(content)) {
+    return true;
+  }
+  const lower = content.toLowerCase();
+  return lower.includes('eth') || lower.includes('wei') || lower.includes('gwei') || lower.includes('ether');
+}
+
+export const ethereumConverterClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.ETHEREUM_CONVERTER,
+  supportedTypes: ['string'],
+  detect: isLikelyEthereum,
+};
+
+registerClipboardTool(ethereumConverterClipboardRegistration);
+

--- a/shared/src/file-generator/clipboard-registration.ts
+++ b/shared/src/file-generator/clipboard-registration.ts
@@ -1,0 +1,9 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const fileGeneratorClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.FILE_GENERATOR,
+  supportedTypes: ['string', 'photo', 'video'],
+};
+
+registerClipboardTool(fileGeneratorClipboardRegistration);
+

--- a/shared/src/file-hash-compare/clipboard-registration.ts
+++ b/shared/src/file-hash-compare/clipboard-registration.ts
@@ -1,0 +1,9 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const fileHashCompareClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.FILE_HASH_COMPARE,
+  supportedTypes: ['string', 'photo', 'video'],
+};
+
+registerClipboardTool(fileHashCompareClipboardRegistration);
+

--- a/shared/src/html-text-extractor/clipboard-registration.ts
+++ b/shared/src/html-text-extractor/clipboard-registration.ts
@@ -1,0 +1,11 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+import { isLikelyHtml } from './index';
+
+export const htmlTextExtractorClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.HTML_TEXT_EXTRACTOR,
+  supportedTypes: ['string'],
+  detect: isLikelyHtml,
+};
+
+registerClipboardTool(htmlTextExtractorClipboardRegistration);
+

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -77,5 +77,19 @@ export * from './text-to-slug';
 // Export Ethereum Converter
 export * from './ethereum-converter';
 
+// Clipboard tool registrations
+export * from './base64-codec/clipboard-registration';
+export * from './binary-base64-codec/clipboard-registration';
+export * from './file-hash-compare/clipboard-registration';
+export * from './html-text-extractor/clipboard-registration';
+export * from './json-formatter/clipboard-registration';
+export * from './text-hash-generator/clipboard-registration';
+export * from './url-encoder/clipboard-registration';
+export * from './file-generator/clipboard-registration';
+export * from './uuid-generator/clipboard-registration';
+export * from './speech-length-estimator/clipboard-registration';
+export * from './text-to-slug/clipboard-registration';
+export * from './ethereum-converter/clipboard-registration';
+
 // Export Unit Converter
 export * from './unit-converter';

--- a/shared/src/json-formatter/clipboard-registration.ts
+++ b/shared/src/json-formatter/clipboard-registration.ts
@@ -1,0 +1,24 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+const JSON_REGEX = /^\s*(\{|\[)[\s\S]*(\}|\])\s*$/;
+
+function isLikelyJson(content: string): boolean {
+  if (!JSON_REGEX.test(content)) {
+    return false;
+  }
+  try {
+    JSON.parse(content);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const jsonFormatterClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.JSON_FORMATTER,
+  supportedTypes: ['string'],
+  detect: isLikelyJson,
+};
+
+registerClipboardTool(jsonFormatterClipboardRegistration);
+

--- a/shared/src/speech-length-estimator/clipboard-registration.ts
+++ b/shared/src/speech-length-estimator/clipboard-registration.ts
@@ -1,0 +1,9 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const speechLengthEstimatorClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.SPEECH_LENGTH_ESTIMATOR,
+  supportedTypes: ['string'],
+};
+
+registerClipboardTool(speechLengthEstimatorClipboardRegistration);
+

--- a/shared/src/text-hash-generator/clipboard-registration.ts
+++ b/shared/src/text-hash-generator/clipboard-registration.ts
@@ -1,0 +1,9 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const textHashGeneratorClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.TEXT_HASH_GENERATOR,
+  supportedTypes: ['string'],
+};
+
+registerClipboardTool(textHashGeneratorClipboardRegistration);
+

--- a/shared/src/text-to-slug/clipboard-registration.ts
+++ b/shared/src/text-to-slug/clipboard-registration.ts
@@ -1,0 +1,9 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const textToSlugClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.TEXT_TO_SLUG,
+  supportedTypes: ['string'],
+};
+
+registerClipboardTool(textToSlugClipboardRegistration);
+

--- a/shared/src/url-encoder/clipboard-registration.ts
+++ b/shared/src/url-encoder/clipboard-registration.ts
@@ -1,0 +1,9 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const urlEncoderClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.URL_ENCODER,
+  supportedTypes: ['string'],
+};
+
+registerClipboardTool(urlEncoderClipboardRegistration);
+

--- a/shared/src/uuid-generator/clipboard-registration.ts
+++ b/shared/src/uuid-generator/clipboard-registration.ts
@@ -1,0 +1,16 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isLikelyUuid(content: string): boolean {
+  return UUID_REGEX.test(content);
+}
+
+export const uuidGeneratorClipboardRegistration: ClipboardToolRegistration = {
+  id: Tool.UUID_GENERATOR,
+  supportedTypes: ['string'],
+  detect: isLikelyUuid,
+};
+
+registerClipboardTool(uuidGeneratorClipboardRegistration);
+


### PR DESCRIPTION
## Summary
- add clipboard tool registry
- register all existing clipboard tools
- refactor `detectClipboardTools` to use registry
- update detector tests to use registry counts
- document new clipboard registration process

## Testing
- `cd shared && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684abf9be64883259ec509c4f399c644