### PR TITLE
Fix sequential desktop tests

### DIFF
--- a/desktop/vitest.config.ts
+++ b/desktop/vitest.config.ts
@@ -13,5 +13,10 @@ export default defineConfig({
       }),
     },
     retry: process.env.CI === 'true' ? 2 : 0,
+    // Run tests sequentially to avoid parallel Electron launches
+    maxConcurrency: 1,
+    sequence: {
+      concurrent: false,
+    },
   },
 })

--- a/desktop/vitest.config.ts
+++ b/desktop/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     sequence: {
       concurrent: false,
     },
+    fileParallelism: false,
     poolOptions: {
       threads: {
         singleThread: true,

--- a/desktop/vitest.config.ts
+++ b/desktop/vitest.config.ts
@@ -18,5 +18,10 @@ export default defineConfig({
     sequence: {
       concurrent: false,
     },
+    poolOptions: {
+      threads: {
+        singleThread: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- run Vitest sequentially for desktop tests

## Testing
- `pnpm test` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_684acae6079c83259e8454a73d250b6b