### PR TITLE
Add desktop UUID generator

### DIFF
--- a/.cursor/rules/desktop-feature.mdc
+++ b/.cursor/rules/desktop-feature.mdc
@@ -62,5 +62,6 @@ alwaysApply: false
      3. Input: Test with valid and invalid inputs
      4. Verification: Wait for and verify correct output
      5. Error handling: Verify appropriate error messages
-   - Use utilities from `/desktop/test/utils.ts` to handle waiting
-   - Run with `pnpm run test`
+  - Use utilities from `/desktop/test/utils.ts` to handle waiting
+  - Run tests locally with `pnpm run test`
+  - Use `pnpm run test:no-screen` to run tests on devices without a screen (wraps Vitest with `xvfb-run`)

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,8 @@
     "build": "tsc && vite build && electron-builder",
     "preview": "vite preview",
     "pretest": "vite build --mode=test",
-    "test": "xvfb-run -a vitest run",
+    "test": "vitest run",
+    "test:no-screen": "xvfb-run -a vitest run",
     "types:check": "tsc --noEmit"
   },
   "debug": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,8 @@
     "build": "tsc && vite build && electron-builder",
     "preview": "vite preview",
     "pretest": "vite build --mode=test",
-    "test": "vitest run"
+    "test": "xvfb-run -a vitest run",
+    "types:check": "tsc --noEmit"
   },
   "debug": {
     "env": {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1,16 +1,18 @@
 import { useState, useEffect } from 'react'
-import { 
-  BracketsIcon, 
+import {
+  BracketsIcon,
   Hash,
   Link2Icon,
   ClipboardIcon,
-  Clock
+  Clock,
+  Fingerprint
 } from 'lucide-react'
 import { Sidebar, Tool } from './components/sidebar'
 import { JsonFormatter } from './components/json-formatter'
 import { ToolPlaceholder } from './components/tool-placeholder'
 import { Base64Codec } from './components/base64-codec'
 import { UrlEncoder } from './components/url-encoder'
+import { UuidGenerator } from './components/uuid-generator'
 
 import { ClipboardDetector } from './components/clipboard-detector'
 import { ClipboardDebug } from './components/clipboard-debug'
@@ -24,6 +26,7 @@ const tools: Tool[] = [
   { id: 'json-formatter', name: 'JSON Format/Validate', icon: <BracketsIcon size={16} /> },
   { id: 'base64-string', name: 'Base64 String Encode/Decode', icon: <Hash size={16} /> },
   { id: 'url-encoder', name: 'URL Encoder/Decoder', icon: <Link2Icon size={16} /> },
+  { id: 'uuid-generator', name: 'UUID Generator', icon: <Fingerprint size={16} /> },
   { id: 'speech-length-estimator', name: 'Speech Length Estimator', icon: <Clock size={16} /> },
   { id: 'ethereum-converter', name: 'Ethereum Converter', icon: <Hash size={16} /> },
   { id: 'unit-converter', name: 'Unit Converter', icon: <Hash size={16} /> },
@@ -111,6 +114,8 @@ function App() {
           <Base64Codec className="min-h-full" />
         ) : selectedTool === 'url-encoder' ? (
           <UrlEncoder className="min-h-full" />
+        ) : selectedTool === 'uuid-generator' ? (
+          <UuidGenerator className="min-h-full" />
         ) : selectedTool === 'speech-length-estimator' ? (
           <SpeechLengthEstimator className="min-h-full" />
         ) : selectedTool === 'ethereum-converter' ? (

--- a/desktop/src/components/uuid-generator.tsx
+++ b/desktop/src/components/uuid-generator.tsx
@@ -1,0 +1,259 @@
+import { useState, useEffect } from "react";
+import { AlertCircle, Check, Copy, RefreshCw } from "lucide-react";
+import {
+  generateUUID,
+  generateMultipleUUIDs,
+  validateUUID,
+  UUIDVersion,
+  UUIDNamespace
+} from "shared/uuid-generator";
+import { Button } from "./ui/button";
+import { Textarea } from "./ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+
+interface UuidGeneratorProps {
+  className?: string;
+}
+
+export function UuidGenerator({ className = "" }: UuidGeneratorProps) {
+  const [output, setOutput] = useState("");
+  const [count, setCount] = useState<number>(1);
+  const [uuidVersion, setUuidVersion] = useState<UUIDVersion>(UUIDVersion.V4);
+  const [uppercase, setUppercase] = useState(false);
+  const [hyphens, setHyphens] = useState(true);
+  const [namespace, setNamespace] = useState<string>(UUIDNamespace.URL);
+  const [customNamespace, setCustomNamespace] = useState("");
+  const [name, setName] = useState("");
+  const [validateInput, setValidateInput] = useState("");
+  const [validationResult, setValidationResult] = useState<boolean | null>(null);
+  const [mode, setMode] = useState<"generate" | "validate">("generate");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const clipboardContent = localStorage.getItem('clipboard-content-for-tool');
+    if (clipboardContent) {
+      setValidateInput(clipboardContent);
+      localStorage.removeItem('clipboard-content-for-tool');
+    }
+  }, []);
+
+  const handleGenerate = () => {
+    try {
+      let result = "";
+      const options = {
+        version: uuidVersion,
+        uppercase,
+        hyphens,
+        name,
+        namespace,
+        customNamespace,
+      };
+      if (count === 1) {
+        result = generateUUID(options);
+      } else {
+        result = generateMultipleUUIDs(count, options).join('\n');
+      }
+      setOutput(result);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+      setOutput("");
+    }
+  };
+
+  const handleValidate = () => {
+    try {
+      if (!validateInput.trim()) {
+        setValidationResult(null);
+        return;
+      }
+      const isValid = validateUUID(validateInput);
+      setValidationResult(isValid);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+      setValidationResult(null);
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(output);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleTabChange = (value: string) => {
+    setMode(value as "generate" | "validate");
+    setError(null);
+    setOutput("");
+    setValidationResult(null);
+  };
+
+  const handleCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value);
+    if (!isNaN(value) && value > 0 && value <= 100) {
+      setCount(value);
+    }
+  };
+
+  const needsNameInput = uuidVersion === UUIDVersion.V5;
+  const needsCustomNamespace = needsNameInput && namespace === UUIDNamespace.CUSTOM;
+
+  return (
+    <div className={`p-4 h-full flex flex-col ${className}`}>
+      <Card className="flex-1 flex flex-col">
+        <CardHeader className="pb-3">
+          <CardTitle>UUID Generator</CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 flex flex-col">
+          <div className="space-y-4 flex-1 flex flex-col">
+            <Tabs value={mode} onValueChange={handleTabChange} className="w-auto">
+              <TabsList className="grid grid-cols-2 w-[200px]">
+                <TabsTrigger value="generate">Generate</TabsTrigger>
+                <TabsTrigger value="validate">Validate</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {mode === 'generate' ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-4">
+                  <div>
+                    <label htmlFor="uuid-v4" className="text-sm font-medium block mb-1">UUID Version</label>
+                    <div className="space-y-2">
+                      <div className="flex items-center space-x-2">
+                        <input type="radio" id="uuid-v4" name="uuid-version" value={UUIDVersion.V4} checked={uuidVersion===UUIDVersion.V4} onChange={(e)=>setUuidVersion(e.target.value as UUIDVersion)} className="h-4 w-4" />
+                        <label htmlFor="uuid-v4" className="text-sm">v4 (Random)</label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <input type="radio" id="uuid-v1" name="uuid-version" value={UUIDVersion.V1} checked={uuidVersion===UUIDVersion.V1} onChange={(e)=>setUuidVersion(e.target.value as UUIDVersion)} className="h-4 w-4" />
+                        <label htmlFor="uuid-v1" className="text-sm">v1 (Timestamp)</label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <input type="radio" id="uuid-v6" name="uuid-version" value={UUIDVersion.V6} checked={uuidVersion===UUIDVersion.V6} onChange={(e)=>setUuidVersion(e.target.value as UUIDVersion)} className="h-4 w-4" />
+                        <label htmlFor="uuid-v6" className="text-sm">v6 (Timestamp reordered)</label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <input type="radio" id="uuid-v7" name="uuid-version" value={UUIDVersion.V7} checked={uuidVersion===UUIDVersion.V7} onChange={(e)=>setUuidVersion(e.target.value as UUIDVersion)} className="h-4 w-4" />
+                        <label htmlFor="uuid-v7" className="text-sm">v7 (Random with timestamp)</label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <input type="radio" id="uuid-v5" name="uuid-version" value={UUIDVersion.V5} checked={uuidVersion===UUIDVersion.V5} onChange={(e)=>setUuidVersion(e.target.value as UUIDVersion)} className="h-4 w-4" />
+                        <label htmlFor="uuid-v5" className="text-sm">v5 (Namespace)</label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <input type="radio" id="uuid-nil" name="uuid-version" value={UUIDVersion.NIL} checked={uuidVersion===UUIDVersion.NIL} onChange={(e)=>setUuidVersion(e.target.value as UUIDVersion)} className="h-4 w-4" />
+                        <label htmlFor="uuid-nil" className="text-sm">NIL (All zeros)</label>
+                      </div>
+                      <div className="flex items-center space-x-2">
+                        <input type="radio" id="uuid-max" name="uuid-version" value={UUIDVersion.MAX} checked={uuidVersion===UUIDVersion.MAX} onChange={(e)=>setUuidVersion(e.target.value as UUIDVersion)} className="h-4 w-4" />
+                        <label htmlFor="uuid-max" className="text-sm">MAX (All ones)</label>
+                      </div>
+                    </div>
+                  </div>
+                  {needsNameInput && (
+                    <>
+                      <div>
+                        <label htmlFor="uuid-name" className="text-sm font-medium block mb-1">Name</label>
+                        <input id="uuid-name" value={name} onChange={(e)=>setName(e.target.value)} className="w-full border rounded h-8 px-2 text-sm" placeholder="Name for v5" />
+                      </div>
+                      <div>
+                        <label htmlFor="namespace" className="text-sm font-medium block mb-1">Namespace</label>
+                        <div className="space-y-2">
+                          <div className="flex items-center space-x-2">
+                            <input type="radio" id="ns-url" name="namespace" value={UUIDNamespace.URL} checked={namespace===UUIDNamespace.URL} onChange={(e)=>setNamespace(e.target.value)} className="h-4 w-4" />
+                            <label htmlFor="ns-url" className="text-sm">URL</label>
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            <input type="radio" id="ns-dns" name="namespace" value={UUIDNamespace.DNS} checked={namespace===UUIDNamespace.DNS} onChange={(e)=>setNamespace(e.target.value)} className="h-4 w-4" />
+                            <label htmlFor="ns-dns" className="text-sm">DNS</label>
+                          </div>
+                          <div className="flex items-center space-x-2">
+                            <input type="radio" id="ns-custom" name="namespace" value={UUIDNamespace.CUSTOM} checked={namespace===UUIDNamespace.CUSTOM} onChange={(e)=>setNamespace(e.target.value)} className="h-4 w-4" />
+                            <label htmlFor="ns-custom" className="text-sm">Custom</label>
+                          </div>
+                        </div>
+                      </div>
+                      {needsCustomNamespace && (
+                        <div>
+                          <label htmlFor="custom-namespace" className="text-sm font-medium block mb-1">Custom Namespace UUID</label>
+                          <input id="custom-namespace" value={customNamespace} onChange={(e)=>setCustomNamespace(e.target.value)} className="w-full border rounded h-8 px-2 text-sm" placeholder="Valid UUID" />
+                        </div>
+                      )}
+                    </>
+                  )}
+                  <div>
+                    <label htmlFor="count" className="text-sm font-medium block mb-1">Number of UUIDs</label>
+                    <input id="count" type="number" min="1" max="100" value={count} onChange={handleCountChange} className="w-full border rounded h-8 px-2 text-sm" />
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <input type="checkbox" id="uppercase" checked={uppercase} onChange={(e)=>setUppercase(e.target.checked)} className="h-4 w-4" />
+                    <label htmlFor="uppercase" className="text-sm">Uppercase</label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <input type="checkbox" id="hyphens" checked={hyphens} onChange={(e)=>setHyphens(e.target.checked)} className="h-4 w-4" />
+                    <label htmlFor="hyphens" className="text-sm">Include hyphens</label>
+                  </div>
+                  <Button onClick={handleGenerate} className="w-full flex items-center gap-2">
+                    <RefreshCw className="h-4 w-4" />
+                    Generate UUID{count > 1 ? 's' : ''}
+                  </Button>
+                </div>
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <label htmlFor="output" className="text-sm font-medium">Generated UUID{count>1?'s':''}</label>
+                    {output && (
+                      <Button size="sm" variant="outline" className="flex items-center gap-1 h-7 px-2 text-xs" onClick={handleCopy}>
+                        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                        {copied ? 'Copied!' : 'Copy'}
+                      </Button>
+                    )}
+                  </div>
+                  {error ? (
+                    <div className="rounded-md bg-destructive/15 p-3 text-destructive">
+                      <div className="flex items-center gap-2">
+                        <AlertCircle className="h-4 w-4" />
+                        <div className="font-medium">Error</div>
+                      </div>
+                      <div className="mt-2 text-sm">{error}</div>
+                    </div>
+                  ) : (
+                    <Textarea id="output" className="min-h-[300px] font-mono w-full" placeholder="Generated UUIDs will appear here..." value={output} readOnly />
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <label htmlFor="validate-input" className="text-sm font-medium">UUID to validate</label>
+                  <Textarea id="validate-input" className="min-h-[200px] font-mono w-full mt-2" placeholder="Enter a UUID to validate..." value={validateInput} onChange={(e)=>setValidateInput(e.target.value)} />
+                  <Button onClick={handleValidate} className="w-full mt-4">Validate UUID</Button>
+                </div>
+                <div>
+                  <label className="text-sm font-medium">Validation Result</label>
+                  {error ? (
+                    <div className="rounded-md bg-destructive/15 p-3 text-destructive mt-2">
+                      <div className="flex items-center gap-2">
+                        <AlertCircle className="h-4 w-4" />
+                        <div className="font-medium">Error</div>
+                      </div>
+                      <div className="mt-2 text-sm">{error}</div>
+                    </div>
+                  ) : validationResult !== null ? (
+                    <div className={`rounded-md p-3 mt-2 ${validationResult ? 'bg-muted/50' : 'bg-destructive/15 text-destructive'}`}> 
+                      {validationResult ? 'Valid UUID' : 'Invalid UUID'}
+                    </div>
+                  ) : (
+                    <div className="text-muted-foreground mt-2 text-sm">Enter a UUID above and click Validate to check.</div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default UuidGenerator;

--- a/desktop/test/utils.ts
+++ b/desktop/test/utils.ts
@@ -310,12 +310,11 @@ export async function waitForTextareaOutput(page: Page, options: WaitForOutputOp
     // Create a condition function based on the provided options
     await page.waitForFunction((opts) => {
       const textareas = document.querySelectorAll('textarea');
-      
-      // We need at least 2 textareas (input and output)
-      if (textareas.length < 2) return false;
-      
-      // Get the output textarea (usually the second one, index 1)
-      const outputTextarea = textareas[1];
+
+      if (textareas.length === 0) return false;
+
+      // Use the last textarea on the page as output
+      const outputTextarea = textareas[textareas.length - 1];
       const outputValue = outputTextarea.value;
       
       // If no output yet, condition is not met
@@ -337,4 +336,14 @@ export async function waitForTextareaOutput(page: Page, options: WaitForOutputOp
     console.error('Error waiting for textarea output:', error);
     throw new Error(`Timed out waiting for textarea output: ${JSON.stringify(options)}`);
   }
-}        
+}
+
+/**
+ * Waits for text content to appear on the page
+ * @param {Page} page - Playwright page object
+ * @param {string} text - The text to wait for
+ * @param {number} timeout - Timeout in milliseconds
+ */
+export async function waitForText(page: Page, text: string, timeout = 5000): Promise<void> {
+  await page.waitForSelector(`text=${text}`, { timeout });
+}

--- a/desktop/test/uuid-generator.spec.ts
+++ b/desktop/test/uuid-generator.spec.ts
@@ -1,0 +1,79 @@
+import * as path from 'node:path'
+import {
+  type ElectronApplication,
+  type Page,
+  type JSHandle,
+} from 'playwright'
+import type { BrowserWindow } from 'electron'
+import {
+  beforeAll,
+  afterAll,
+  describe,
+  expect,
+  test,
+} from 'vitest'
+import {
+  launchElectronWithRetry,
+  findButtonByText,
+  takeScreenshot,
+  navigateToTool,
+  fillTextareaInput,
+  waitForTextareaOutput,
+  waitForText,
+} from './utils'
+
+const root = path.join(__dirname, '..')
+let electronApp: ElectronApplication | null = null
+let page: Page | null = null
+
+const TOOL_BUTTON_NAME = 'UUID Generator'
+const COMPONENT_TITLE = 'UUID Generator'
+const isCI = process.env.CI === 'true'
+
+describe('UUID Generator tests', async () => {
+  beforeAll(async () => {
+    try {
+      electronApp = await launchElectronWithRetry()
+      page = await electronApp.firstWindow()
+      const loadTimeout = isCI ? 30000 : 10000
+      await page.waitForLoadState('domcontentloaded', { timeout: loadTimeout })
+      const mainWin: JSHandle<BrowserWindow> = await electronApp.browserWindow(page)
+      await mainWin.evaluate(async (win) => {
+        win.webContents.executeJavaScript('// Test initialization complete')
+      })
+    } catch (error) {
+      console.error('Setup failed:', error)
+      throw error
+    }
+  })
+
+  afterAll(async () => {
+    if (page) {
+      await page.close().catch(err => console.error('Error closing page:', err))
+    }
+    if (electronApp) {
+      await electronApp.close().catch(err => console.error('Error closing app:', err))
+    }
+  })
+
+  test('should generate a v4 UUID', async () => {
+    expect(page).not.toBeNull()
+    await navigateToTool(page, TOOL_BUTTON_NAME, COMPONENT_TITLE)
+    await takeScreenshot(page, 'uuid-generator', 'initial')
+    await (await findButtonByText(page, 'Generate UUID')).click()
+    const output = await page.$('textarea');
+    await page.waitForFunction(el => (el as HTMLTextAreaElement).value.length > 0, output)
+    await takeScreenshot(page, 'uuid-generator', 'generated', true)
+  })
+
+  test('should validate UUID correctly', async () => {
+    expect(page).not.toBeNull()
+    await navigateToTool(page, TOOL_BUTTON_NAME, COMPONENT_TITLE)
+    await (await findButtonByText(page, 'Validate')).click()
+    const validUuid = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+    await fillTextareaInput(page, validUuid)
+    await (await findButtonByText(page, 'Validate UUID')).click()
+    await waitForText(page, 'Valid UUID')
+    await takeScreenshot(page, 'uuid-generator', 'validate', true)
+  })
+})


### PR DESCRIPTION
## Summary
- implement a new UUID Generator component for the desktop app
- register the UUID Generator tool in `App.tsx`
- add end-to-end tests for UUID Generator
- fix test environment with `xvfb-run` and add type checking script

## Testing
- `pnpm -r run lint`
- `pnpm -r run types:check`
- `pnpm -r run test`


------
https://chatgpt.com/codex/tasks/task_e_684ad40331d08325afbc900a4994f772