### PR TITLE
Use Node 20 in release workflows

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
## Summary
- use Node.js 20 instead of 18 for the release workflows

## Testing
- `pnpm -r lint`
- `pnpm -r types:check`
- `pnpm -r test` *(fails: electron.launch Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5bdaa4083259a8cf8edfc348b93