### PR TITLE
Add update checker page with logs

### DIFF
--- a/desktop/electron/main/index.ts
+++ b/desktop/electron/main/index.ts
@@ -432,6 +432,11 @@ ipcMain.handle('minimize-to-tray', () => {
   }
 })
 
+// Provide application version to renderer
+ipcMain.handle('get-app-version', () => {
+  return app.getVersion()
+})
+
 // Update tray menu dynamically
 ipcMain.handle('update-tray-menu', (_, items) => {
   if (tray) {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -5,7 +5,8 @@ import {
   Link2Icon,
   ClipboardIcon,
   Clock,
-  Fingerprint
+  Fingerprint,
+  RefreshCw
 } from 'lucide-react'
 import { Sidebar, Tool } from './components/sidebar'
 import { JsonFormatter } from './components/json-formatter'
@@ -19,6 +20,7 @@ import { ClipboardDebug } from './components/clipboard-debug'
 import { EthereumConverter } from './components/ethereum-converter'
 import { UnitConverter } from './components/unit-converter'
 import { SpeechLengthEstimator } from './components/speech-length-estimator'
+import UpdatesPage from './components/updates-page'
 
 // List of tools
 const tools: Tool[] = [
@@ -30,6 +32,7 @@ const tools: Tool[] = [
   { id: 'speech-length-estimator', name: 'Speech Length Estimator', icon: <Clock size={16} /> },
   { id: 'ethereum-converter', name: 'Ethereum Converter', icon: <Hash size={16} /> },
   { id: 'unit-converter', name: 'Unit Converter', icon: <Hash size={16} /> },
+  { id: 'updates', name: 'Updates', icon: <RefreshCw size={16} /> },
 ]
 
 /**
@@ -122,6 +125,8 @@ function App() {
           <EthereumConverter className="min-h-full" />
         ) : selectedTool === 'unit-converter' ? (
           <UnitConverter className="min-h-full" />
+        ) : selectedTool === 'updates' ? (
+          <UpdatesPage className="min-h-full" />
         ) : (
           <ToolPlaceholder 
             title={tools.find(t => t.id === selectedTool)?.name || ''}

--- a/desktop/src/components/update/index.tsx
+++ b/desktop/src/components/update/index.tsx
@@ -4,7 +4,11 @@ import Modal from '@/components/update/Modal'
 import Progress from '@/components/update/Progress'
 import './update.css'
 
-const Update = () => {
+interface UpdateProps {
+  showCheckButton?: boolean
+}
+
+const Update = ({ showCheckButton = true }: UpdateProps) => {
   const [checking, setChecking] = useState(false)
   const [updateAvailable, setUpdateAvailable] = useState(false)
   const [versionInfo, setVersionInfo] = useState<VersionInfo>()
@@ -149,9 +153,11 @@ const Update = () => {
               )}
         </div>
       </Modal>
-      <button disabled={checking} onClick={checkUpdate}>
-        {checking ? 'Checking...' : 'Check update'}
-      </button>
+      {showCheckButton && (
+        <button disabled={checking} onClick={checkUpdate}>
+          {checking ? 'Checking...' : 'Check update'}
+        </button>
+      )}
     </>
   )
 }

--- a/desktop/src/components/updates-page.tsx
+++ b/desktop/src/components/updates-page.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import Update from "./update";
+import { Button } from "./ui/button";
+
+interface UpdatesPageProps {
+  className?: string;
+}
+
+function compareVersions(a: string, b: string): number {
+  const pa = a.replace(/^v/, '').split('.').map(Number);
+  const pb = b.replace(/^v/, '').split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+export function UpdatesPage({ className = "" }: UpdatesPageProps) {
+  const [logs, setLogs] = useState<string[]>([]);
+  const [checking, setChecking] = useState(false);
+  const [updateInfo, setUpdateInfo] = useState<{current: string; latest: string} | null>(null);
+
+  const log = (msg: string) => {
+    setLogs(prev => [...prev, msg]);
+    console.log("UpdatesPage:", msg);
+  };
+
+  const checkForUpdates = async () => {
+    const url = "https://api.github.com/repos/IgorShadurin/offlinetools.org/releases/latest";
+    setChecking(true);
+    setUpdateInfo(null);
+    setLogs([]);
+    log(`Fetching ${url}`);
+    try {
+      const current: string = await window.ipcRenderer.invoke('get-app-version');
+      log(`Current version: ${current}`);
+      const resp = await fetch(url);
+      log(`Status: ${resp.status}`);
+      const data = await resp.json();
+      log(`Response: ${JSON.stringify(data)}`);
+      const latest = (data.tag_name || data.name || '').replace(/^v/, '');
+      if (latest && compareVersions(latest, current) > 0) {
+        setUpdateInfo({ current, latest });
+        log(`Update available: v${latest}`);
+      } else {
+        log('No update available');
+      }
+    } catch (e: any) {
+      log(`Error: ${e.message}`);
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const startUpdate = async () => {
+    log('Starting update via autoUpdater');
+    await window.ipcRenderer.invoke('check-update');
+  };
+
+  return (
+    <div className={`p-4 flex flex-col h-full ${className}`}>
+      <div className="mb-4 flex items-center gap-2">
+        <Button onClick={checkForUpdates} disabled={checking}>
+          {checking ? 'Checking...' : 'Check for Updates'}
+        </Button>
+        {updateInfo && (
+          <Button onClick={startUpdate} variant="secondary">
+            Update to v{updateInfo.latest}
+          </Button>
+        )}
+      </div>
+      <pre className="flex-1 overflow-auto rounded bg-muted/50 p-2 text-xs whitespace-pre-wrap">
+        {logs.join('\n')}
+      </pre>
+      {/* Hidden Update component for progress modal */}
+      <Update showCheckButton={false} />
+    </div>
+  );
+}
+
+export default UpdatesPage;

--- a/desktop/src/type/electron.d.ts
+++ b/desktop/src/type/electron.d.ts
@@ -6,6 +6,7 @@ interface IpcRenderer {
   off(channel: string, listener: (...args: any[]) => void): void;
   once(channel: string, listener: (...args: any[]) => void): void;
   send(channel: string, ...args: any[]): void;
+  invoke(channel: 'get-app-version'): Promise<string>;
   invoke(channel: string, ...args: any[]): Promise<any>;
   removeAllListeners(channel: string): void;
 }


### PR DESCRIPTION
## Summary
- add IPC handler to retrieve app version
- extend electron typings
- support hiding check button in update modal
- add UpdatesPage component with log output
- expose Updates page in sidebar

## Testing
- `pnpm -r lint`
- `pnpm -r types:check`
- `pnpm -r test` *(fails: Failed to launch Electron)*

------
https://chatgpt.com/codex/tasks/task_e_684af2dcf7708325b6a793474bc81920