### PR TITLE
Add Person Generator feature

### DIFF
--- a/landing/app/tools/person-generator/PersonGenerator.tsx
+++ b/landing/app/tools/person-generator/PersonGenerator.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Container } from "@/components/ui/container";
+import { SectionHeading } from "@/components/ui/section";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  generatePeople,
+  formatPeople,
+  PersonField,
+  PersonOutputFormat,
+  DEFAULT_PERSON_FIELDS,
+  DEFAULT_PERSON_TEMPLATE,
+  isFileSystemAccessSupported,
+  generateFileDownloadUrl,
+} from "shared";
+import { AlertCircle, Check, Copy, FileDown, Pencil, Link as LinkIcon } from "lucide-react";
+import Link from "next/link";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import PersonGeneratorExplanation from "./PersonGeneratorExplanation";
+import * as Dialog from "@radix-ui/react-dialog";
+
+const ALL_FIELDS = Object.values(PersonField);
+
+export default function PersonGenerator() {
+  const [count, setCount] = useState(1);
+  const [fields, setFields] = useState<PersonField[]>(DEFAULT_PERSON_FIELDS);
+  const [format, setFormat] = useState<PersonOutputFormat>(PersonOutputFormat.JSON);
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [fsApi, setFsApi] = useState(false);
+  const [template, setTemplate] = useState(DEFAULT_PERSON_TEMPLATE);
+  const [showTemplate, setShowTemplate] = useState(false);
+
+  useEffect(() => {
+    setFsApi(isFileSystemAccessSupported());
+    if (typeof window !== "undefined") {
+      const storedFields = localStorage.getItem("personFields");
+      if (storedFields) setFields(JSON.parse(storedFields));
+      const storedTemplate = localStorage.getItem("personTemplate");
+      if (storedTemplate) setTemplate(storedTemplate);
+    }
+  }, []);
+
+  const toggleField = (f: PersonField) => {
+    setFields((prev) => {
+      const next = prev.includes(f) ? prev.filter((v) => v !== f) : [...prev, f];
+      if (typeof window !== "undefined") {
+        localStorage.setItem("personFields", JSON.stringify(next));
+      }
+      return next;
+    });
+  };
+
+  const handleGenerate = () => {
+    try {
+      const people = generatePeople(count, { fields });
+      const text = formatPeople(people, format, template);
+      setOutput(text);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+      setOutput("");
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(output);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleSave = async () => {
+    if (!output) return;
+    const blob = new Blob([output], { type: "text/plain" });
+    if (fsApi) {
+      try {
+        // @ts-expect-error - not typed in all browsers
+        const handle = await window.showSaveFilePicker({
+          suggestedName: `people.${format}`,
+        });
+        const writable = await handle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    } else {
+      const { url, revoke } = generateFileDownloadUrl(blob, format);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `people.${format}`;
+      a.click();
+      revoke();
+    }
+  };
+
+  const saveTemplate = () => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("personTemplate", template);
+    }
+    setShowTemplate(false);
+  };
+
+  const resetTemplate = () => {
+    setTemplate(DEFAULT_PERSON_TEMPLATE);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("personTemplate");
+    }
+  };
+
+  return (
+    <>
+      <Container className="py-8 md:py-12">
+        <SectionHeading
+          title="Person Generator"
+          description="Generate fake person data in various formats with customizable fields."
+        />
+
+        <div className="mb-4 flex items-center text-sm text-muted-foreground gap-2">
+          <LinkIcon className="h-4 w-4" />
+          <span>Related tool: </span>
+          <Link href="/tools/file-generator" className="text-primary hover:underline">
+            File Generator
+          </Link>
+        </div>
+
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <div>
+                <Label htmlFor="count">Number of people</Label>
+                <Input
+                  id="count"
+                  type="number"
+                  min={1}
+                  max={100}
+                  value={count}
+                  onChange={(e) => setCount(parseInt(e.target.value) || 1)}
+                  className="mt-1"
+                />
+              </div>
+
+              <div>
+                <Label>Fields</Label>
+                <div className="grid grid-cols-2 gap-2 mt-2">
+                  {ALL_FIELDS.map((f) => (
+                    <label key={f} className="flex items-center space-x-2">
+                      <Checkbox
+                        id={f}
+                        checked={fields.includes(f)}
+                        onCheckedChange={() => toggleField(f)}
+                      />
+                      <span className="capitalize">{f}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <Label>Format</Label>
+                <RadioGroup value={format} onValueChange={(v) => setFormat(v as PersonOutputFormat)} className="mt-2 space-y-1">
+                  {Object.values(PersonOutputFormat).map((v) => (
+                    <div key={v} className="flex items-center space-x-2">
+                      <RadioGroupItem value={v} id={v} />
+                      <Label htmlFor={v}>{v.toUpperCase()}</Label>
+                    </div>
+                  ))}
+                </RadioGroup>
+              </div>
+
+              {format === PersonOutputFormat.CUSTOM && (
+                <Button type="button" variant="outline" onClick={() => setShowTemplate(true)} className="mt-2 flex items-center gap-1">
+                  <Pencil className="h-4 w-4" /> Edit Template
+                </Button>
+              )}
+
+              <Button onClick={handleGenerate} className="w-full mt-4">
+                Generate
+              </Button>
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <Label>Output</Label>
+                {output && (
+                  <Button size="sm" variant="outline" className="flex items-center gap-1" onClick={handleCopy}>
+                    {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    {copied ? "Copied" : "Copy"}
+                  </Button>
+                )}
+              </div>
+              {error ? (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Error</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              ) : (
+                <Textarea className="min-h-[300px] font-mono" value={output} readOnly placeholder="Generated data will appear here" />
+              )}
+              {output && (
+                <Button onClick={handleSave} className="w-full mt-4 flex items-center gap-1" variant="outline">
+                  <FileDown className="h-4 w-4" /> Save as File
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </Container>
+
+      <Container className="py-8 md:py-12">
+        <PersonGeneratorExplanation />
+      </Container>
+
+      <Dialog.Root open={showTemplate} onOpenChange={setShowTemplate}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+          <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background p-6 rounded-md w-[90vw] max-w-lg space-y-4">
+            <Dialog.Title className="text-lg font-medium">Edit Template</Dialog.Title>
+            <p className="text-sm text-muted-foreground">
+              Available variables: {ALL_FIELDS.map((f) => `{{${f}}}`).join(", ")}
+            </p>
+            <Textarea value={template} onChange={(e) => setTemplate(e.target.value)} className="font-mono min-h-[150px]" />
+            <div className="flex gap-2 justify-end">
+              <Button variant="outline" onClick={resetTemplate}>Reset</Button>
+              <Button onClick={saveTemplate}>Save</Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/landing/app/tools/person-generator/PersonGeneratorExplanation.tsx
+++ b/landing/app/tools/person-generator/PersonGeneratorExplanation.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+export default function PersonGeneratorExplanation() {
+  return (
+    <div className="p-6 border rounded-lg bg-card text-card-foreground shadow-sm">
+      <h2 className="text-2xl font-bold mb-4">About Person Generator</h2>
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-xl font-semibold mb-2">Tool Capabilities</h3>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>Create realistic person data for testing</li>
+            <li>Select which fields to include</li>
+            <li>Export data as JSON, XML, YAML, HTML, or plain text</li>
+            <li>Design custom output using template variables</li>
+            <li>Save generated data directly to a file</li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold mb-2">Common Use Cases</h3>
+          <ol className="list-decimal pl-6 space-y-3">
+            <li><strong>Database seeding</strong><p>Fill development databases with sample user records.</p></li>
+            <li><strong>UI mockups</strong><p>Populate designs with realistic names and contact details.</p></li>
+            <li><strong>Testing exports</strong><p>Generate bulk data to test CSV or JSON import features.</p></li>
+            <li><strong>Privacy protection</strong><p>Use fake data instead of real customer information.</p></li>
+            <li><strong>Education</strong><p>Demonstrate data processing pipelines without sensitive data.</p></li>
+          </ol>
+        </div>
+        <div>
+          <h3 className="text-xl font-semibold mb-2">Technical Details</h3>
+          <p>
+            Person records are generated with the @faker-js/faker library and formatted
+            using built-in conversion functions. Templates replace variables like
+            <code>{`{{firstName}}`}</code> with generated values.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/landing/app/tools/person-generator/page.tsx
+++ b/landing/app/tools/person-generator/page.tsx
@@ -1,0 +1,11 @@
+import PersonGenerator from './PersonGenerator';
+
+export const metadata = {
+  title: 'Person Generator',
+  description:
+    'Generate fake person data in various formats with customizable fields.',
+};
+
+export default function PersonGeneratorPage() {
+  return <PersonGenerator />;
+}

--- a/landing/components/online-tools-grid.tsx
+++ b/landing/components/online-tools-grid.tsx
@@ -52,6 +52,11 @@ export const onlineTools = [
     description: "Generate files with specific size and format with random data, zeros, or custom patterns.",
   },
   {
+    title: "Person Generator",
+    path: "/tools/person-generator",
+    description: "Create fake person data with chosen fields in multiple formats.",
+  },
+  {
     title: "UUID Generator",
     path: "/tools/uuid-generator",
     description: "Generate universally unique identifiers (UUIDs) in various formats (v1, v4, v5, v6, v7).",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
 
   shared:
     dependencies:
+      '@faker-js/faker':
+        specifier: ^9.8.0
+        version: 9.8.0
       html-to-text:
         specifier: ^9.0.5
         version: 9.0.5
@@ -219,6 +222,9 @@ importers:
       js-sha3:
         specifier: ^0.9.3
         version: 0.9.3
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -229,6 +235,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.14
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^20
         version: 20.17.47
@@ -705,6 +714,10 @@ packages:
   '@eslint/plugin-kit@0.2.8':
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@faker-js/faker@9.8.0':
+    resolution: {integrity: sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@floating-ui/core@1.7.0':
     resolution: {integrity: sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==}
@@ -1786,6 +1799,9 @@ packages:
 
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -5902,6 +5918,8 @@ snapshots:
       '@eslint/core': 0.13.0
       levn: 0.4.1
 
+  '@faker-js/faker@9.8.0': {}
+
   '@floating-ui/core@1.7.0':
     dependencies:
       '@floating-ui/utils': 0.2.9
@@ -6996,6 +7014,8 @@ snapshots:
     dependencies:
       expect: 29.7.0
       pretty-format: 29.7.0
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -9,16 +9,19 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
+    "@faker-js/faker": "^9.8.0",
     "html-to-text": "^9.0.5",
     "js-md5": "^0.8.3",
     "js-sha1": "^0.7.0",
     "js-sha256": "^0.11.0",
     "js-sha3": "^0.9.3",
+    "js-yaml": "^4.1.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@types/html-to-text": "^9.0.4",
     "@types/jest": "^29.5.12",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.30.1",

--- a/shared/src/clipboard-detector/index.test.ts
+++ b/shared/src/clipboard-detector/index.test.ts
@@ -49,6 +49,7 @@ describe('Clipboard Detector', () => {
       expect(result).toContain(Tool.TEXT_HASH_GENERATOR);
       expect(result).toContain(Tool.URL_ENCODER);
       expect(result).toContain(Tool.FILE_GENERATOR);
+      expect(result).toContain(Tool.PERSON_GENERATOR);
       expect(result).toContain(Tool.UUID_GENERATOR);
       expect(result).toContain(Tool.SPEECH_LENGTH_ESTIMATOR);
       expect(result).toContain(Tool.TEXT_TO_SLUG);
@@ -73,6 +74,7 @@ describe('Clipboard Detector', () => {
       expect(result).toContain(Tool.TEXT_HASH_GENERATOR);
       expect(result).toContain(Tool.URL_ENCODER);
       expect(result).toContain(Tool.FILE_GENERATOR);
+      expect(result).toContain(Tool.PERSON_GENERATOR);
       expect(result).toContain(Tool.UUID_GENERATOR);
       expect(result).toContain(Tool.SPEECH_LENGTH_ESTIMATOR);
       expect(result).toContain(Tool.TEXT_TO_SLUG);
@@ -258,6 +260,7 @@ describe('Clipboard Detector', () => {
       expect(result).toContain(Tool.TEXT_HASH_GENERATOR);
       expect(result).toContain(Tool.URL_ENCODER);
       expect(result).toContain(Tool.FILE_GENERATOR);
+      expect(result).toContain(Tool.PERSON_GENERATOR);
       expect(result).toContain(Tool.UUID_GENERATOR);
       expect(result).toContain(Tool.SPEECH_LENGTH_ESTIMATOR);
       expect(result).toContain(Tool.TEXT_TO_SLUG);

--- a/shared/src/clipboard-detector/index.ts
+++ b/shared/src/clipboard-detector/index.ts
@@ -18,7 +18,8 @@ export enum Tool {
   UUID_GENERATOR = 'uuid-generator',
   SPEECH_LENGTH_ESTIMATOR = 'speech-length-estimator',
   TEXT_TO_SLUG = 'text-to-slug',
-  ETHEREUM_CONVERTER = 'ethereum-converter'
+  ETHEREUM_CONVERTER = 'ethereum-converter',
+  PERSON_GENERATOR = 'person-generator'
 }
 
 /**

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -93,3 +93,9 @@ export * from './ethereum-converter/clipboard-registration';
 
 // Export Unit Converter
 export * from './unit-converter';
+
+// Export Person Generator
+export * from './person-generator';
+
+// Clipboard registration for Person Generator
+export * from './person-generator/clipboard-registration';

--- a/shared/src/person-generator/clipboard-registration.ts
+++ b/shared/src/person-generator/clipboard-registration.ts
@@ -1,0 +1,8 @@
+import { registerClipboardTool, type ClipboardToolRegistration, Tool } from '../clipboard-detector';
+
+export const personGeneratorClipboard: ClipboardToolRegistration = {
+  id: Tool.PERSON_GENERATOR as Tool,
+  supportedTypes: ['string'],
+};
+
+registerClipboardTool(personGeneratorClipboard);

--- a/shared/src/person-generator/index.test.ts
+++ b/shared/src/person-generator/index.test.ts
@@ -1,0 +1,42 @@
+import { faker } from '@faker-js/faker';
+import {
+  generatePeople,
+  formatPeople,
+  PersonField,
+  PersonOutputFormat,
+  DEFAULT_PERSON_TEMPLATE,
+} from './index';
+
+describe('Person Generator', () => {
+  beforeAll(() => {
+    faker.seed(123);
+  });
+
+  it('should generate the requested number of people', () => {
+    const people = generatePeople(3, { fields: [PersonField.firstName] });
+    expect(people).toHaveLength(3);
+    expect(people[0]).toHaveProperty('firstName');
+  });
+
+  it('should return empty array for count <= 0', () => {
+    expect(generatePeople(0)).toEqual([]);
+  });
+
+  it('should format people as JSON', () => {
+    const people = generatePeople(1, { fields: [PersonField.firstName] });
+    const json = formatPeople(people, PersonOutputFormat.JSON);
+    expect(json).toContain('firstName');
+  });
+
+  it('should format people using custom template', () => {
+    const people = generatePeople(1);
+    const text = formatPeople(people, PersonOutputFormat.CUSTOM, '{{email}}');
+    expect(text).toMatch(/@/);
+  });
+
+  it('should use default template when none provided', () => {
+    const people = generatePeople(1);
+    const text = formatPeople(people, PersonOutputFormat.CUSTOM);
+    expect(text).toContain(' - ');
+  });
+});

--- a/shared/src/person-generator/index.ts
+++ b/shared/src/person-generator/index.ts
@@ -1,0 +1,194 @@
+import { faker } from '@faker-js/faker';
+import yaml from 'js-yaml';
+
+/** Available person fields */
+export enum PersonField {
+  firstName = 'firstName',
+  lastName = 'lastName',
+  fullName = 'fullName',
+  gender = 'gender',
+  email = 'email',
+  phone = 'phone',
+  address = 'address',
+  city = 'city',
+  country = 'country',
+  jobTitle = 'jobTitle',
+  birthdate = 'birthdate'
+}
+
+/** Output format options */
+export enum PersonOutputFormat {
+  JSON = 'json',
+  XML = 'xml',
+  YML = 'yml',
+  HTML = 'html',
+  TEXT = 'txt',
+  CUSTOM = 'custom'
+}
+
+/** Default selected fields */
+export const DEFAULT_PERSON_FIELDS: PersonField[] = [
+  PersonField.firstName,
+  PersonField.lastName,
+  PersonField.email
+];
+
+/** Person object type */
+export interface Person {
+  [key: string]: string;
+}
+
+/** Options for generating people */
+export interface PersonGeneratorOptions {
+  /** Fields to include in the output */
+  fields: PersonField[];
+}
+
+/** Default custom template */
+export const DEFAULT_PERSON_TEMPLATE =
+  '{{firstName}} {{lastName}} - {{email}}';
+
+/**
+ * Generate a single person record
+ * @param fields - Fields to include
+ * @returns Person object with requested fields
+ */
+export function generatePerson(fields: PersonField[]): Person {
+  const person: Person = {};
+
+  for (const field of fields) {
+    switch (field) {
+      case PersonField.firstName:
+        person.firstName = faker.person.firstName();
+        break;
+      case PersonField.lastName:
+        person.lastName = faker.person.lastName();
+        break;
+      case PersonField.fullName:
+        person.fullName = faker.person.fullName();
+        break;
+      case PersonField.gender:
+        person.gender = faker.person.sex();
+        break;
+      case PersonField.email:
+        person.email = faker.internet.email();
+        break;
+      case PersonField.phone:
+        person.phone = faker.phone.number();
+        break;
+      case PersonField.address:
+        person.address = faker.location.streetAddress();
+        break;
+      case PersonField.city:
+        person.city = faker.location.city();
+        break;
+      case PersonField.country:
+        person.country = faker.location.country();
+        break;
+      case PersonField.jobTitle:
+        person.jobTitle = faker.person.jobTitle();
+        break;
+      case PersonField.birthdate:
+        person.birthdate = faker.date.birthdate().toISOString().split('T')[0];
+        break;
+    }
+  }
+
+  return person;
+}
+
+/**
+ * Generate multiple person records
+ * @param count - Number of persons
+ * @param options - Generator options
+ * @returns Array of person objects
+ */
+export function generatePeople(
+  count = 1,
+  options: PersonGeneratorOptions = { fields: DEFAULT_PERSON_FIELDS }
+): Person[] {
+  try {
+    if (count <= 0) return [];
+    const fields = options.fields.length
+      ? options.fields
+      : DEFAULT_PERSON_FIELDS;
+
+    const people: Person[] = [];
+    for (let i = 0; i < count; i++) {
+      people.push(generatePerson(fields));
+    }
+    return people;
+  } catch (error) {
+    throw new Error(
+      `Person generation failed: ${(error as Error).message}`
+    );
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Format people records into various formats
+ * @param people - Array of people
+ * @param format - Output format
+ * @param template - Custom template for CUSTOM format
+ * @returns Formatted string
+ */
+export function formatPeople(
+  people: Person[],
+  format: PersonOutputFormat,
+  template = DEFAULT_PERSON_TEMPLATE
+): string {
+  try {
+    switch (format) {
+      case PersonOutputFormat.JSON:
+        return JSON.stringify(people, null, 2);
+      case PersonOutputFormat.XML: {
+        const items = people
+          .map(
+            (p) =>
+              `<person>${Object.entries(p)
+                .map(([k, v]) => `<${k}>${escapeHtml(v)}</${k}>`)
+                .join('')}</person>`
+          )
+          .join('');
+        return `<people>${items}</people>`;
+      }
+      case PersonOutputFormat.YML:
+        return yaml.dump(people);
+      case PersonOutputFormat.HTML: {
+        const headers = Object.keys(people[0] || {});
+        const head = headers.map((h) => `<th>${escapeHtml(h)}</th>`).join('');
+        const rows = people
+          .map(
+            (p) =>
+              `<tr>${headers
+                .map((h) => `<td>${escapeHtml(p[h] ?? '')}</td>`)
+                .join('')}</tr>`
+          )
+          .join('');
+        return `<table><thead><tr>${head}</tr></thead><tbody>${rows}</tbody></table>`;
+      }
+      case PersonOutputFormat.TEXT:
+        return people
+          .map((p) => Object.values(p).join(' '))
+          .join('\n');
+      case PersonOutputFormat.CUSTOM:
+        return people
+          .map((p) =>
+            template.replace(/{{\s*(\w+)\s*}}/g, (_, key) => p[key] || '')
+          )
+          .join('\n');
+      default:
+        return JSON.stringify(people, null, 2);
+    }
+  } catch (error) {
+    throw new Error(`Formatting failed: ${(error as Error).message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `person-generator` shared library
- support multiple output formats and custom templates
- register Person Generator in clipboard detector
- add Person Generator page to landing site with template modal
- include new tool in the online tools list

## Testing
- `cd shared && pnpm test`
- `cd landing && pnpm lint && pnpm types:check`


------
https://chatgpt.com/codex/tasks/task_e_684af5831dec83258b1c695a5eac39cb