### PR TITLE
Add person generator feature to desktop

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import {
   ClipboardIcon,
   Clock,
   Fingerprint,
+  Users,
   RefreshCw
 } from 'lucide-react'
 import { Sidebar, Tool } from './components/sidebar'
@@ -21,6 +22,7 @@ import { EthereumConverter } from './components/ethereum-converter'
 import { UnitConverter } from './components/unit-converter'
 import { SpeechLengthEstimator } from './components/speech-length-estimator'
 import UpdatesPage from './components/updates-page'
+import { PersonGenerator } from './components/person-generator'
 
 // List of tools
 const tools: Tool[] = [
@@ -29,6 +31,7 @@ const tools: Tool[] = [
   { id: 'base64-string', name: 'Base64 String Encode/Decode', icon: <Hash size={16} /> },
   { id: 'url-encoder', name: 'URL Encoder/Decoder', icon: <Link2Icon size={16} /> },
   { id: 'uuid-generator', name: 'UUID Generator', icon: <Fingerprint size={16} /> },
+  { id: 'person-generator', name: 'Person Generator', icon: <Users size={16} /> },
   { id: 'speech-length-estimator', name: 'Speech Length Estimator', icon: <Clock size={16} /> },
   { id: 'ethereum-converter', name: 'Ethereum Converter', icon: <Hash size={16} /> },
   { id: 'unit-converter', name: 'Unit Converter', icon: <Hash size={16} /> },
@@ -119,6 +122,8 @@ function App() {
           <UrlEncoder className="min-h-full" />
         ) : selectedTool === 'uuid-generator' ? (
           <UuidGenerator className="min-h-full" />
+        ) : selectedTool === 'person-generator' ? (
+          <PersonGenerator className="min-h-full" />
         ) : selectedTool === 'speech-length-estimator' ? (
           <SpeechLengthEstimator className="min-h-full" />
         ) : selectedTool === 'ethereum-converter' ? (

--- a/desktop/src/components/person-generator.tsx
+++ b/desktop/src/components/person-generator.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect } from "react";
+import { Check, Copy, FileDown, Pencil } from "lucide-react";
+import {
+  generatePeople,
+  formatPeople,
+  PersonField,
+  PersonOutputFormat,
+  DEFAULT_PERSON_FIELDS,
+  DEFAULT_PERSON_TEMPLATE,
+  isFileSystemAccessSupported,
+  generateFileDownloadUrl,
+} from "shared";
+import { Button } from "./ui/button";
+import { Textarea } from "./ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Alert, AlertDescription } from "./ui/alert";
+import Modal from "./update/Modal";
+
+interface PersonGeneratorProps {
+  className?: string;
+}
+
+const ALL_FIELDS = Object.values(PersonField);
+
+export function PersonGenerator({ className = "" }: PersonGeneratorProps) {
+  const [count, setCount] = useState(1);
+  const [fields, setFields] = useState<PersonField[]>(DEFAULT_PERSON_FIELDS);
+  const [format, setFormat] = useState<PersonOutputFormat>(PersonOutputFormat.JSON);
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [fsApi, setFsApi] = useState(false);
+  const [template, setTemplate] = useState(DEFAULT_PERSON_TEMPLATE);
+  const [showTemplate, setShowTemplate] = useState(false);
+
+  useEffect(() => {
+    setFsApi(isFileSystemAccessSupported());
+  }, []);
+
+  const toggleField = (f: PersonField) => {
+    setFields((prev) =>
+      prev.includes(f) ? prev.filter((v) => v !== f) : [...prev, f]
+    );
+  };
+
+  const handleGenerate = () => {
+    try {
+      const people = generatePeople(count, { fields });
+      const text = formatPeople(people, format, template);
+      setOutput(text);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+      setOutput("");
+    }
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(output);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleSave = async () => {
+    if (!output) return;
+    const blob = new Blob([output], { type: "text/plain" });
+    if (fsApi) {
+      try {
+        // @ts-ignore
+        const handle = await window.showSaveFilePicker({
+          suggestedName: `people.${format}`,
+        });
+        const writable = await handle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    } else {
+      const { url, revoke } = generateFileDownloadUrl(blob, format);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `people.${format}`;
+      a.click();
+      revoke();
+    }
+  };
+
+  const saveTemplate = () => {
+    setShowTemplate(false);
+  };
+
+  const resetTemplate = () => {
+    setTemplate(DEFAULT_PERSON_TEMPLATE);
+  };
+
+  return (
+    <div className={`p-4 h-full flex flex-col ${className}`}>
+      <Card className="flex-1 flex flex-col">
+        <CardHeader className="pb-3">
+          <CardTitle>Person Generator</CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 flex flex-col">
+          <div className="space-y-6 flex-1 flex flex-col">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 flex-1">
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="count" className="block text-sm font-medium mb-1">
+                    Number of people
+                  </label>
+                  <input
+                    id="count"
+                    type="number"
+                    min={1}
+                    max={100}
+                    value={count}
+                    onChange={(e) => setCount(parseInt(e.target.value) || 1)}
+                    className="w-full h-8 px-2 border rounded text-sm"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-sm font-medium">Fields</label>
+                  <div className="grid grid-cols-2 gap-2 mt-2">
+                    {ALL_FIELDS.map((f) => (
+                      <label key={f} className="flex items-center space-x-2 text-sm capitalize">
+                        <input
+                          type="checkbox"
+                          checked={fields.includes(f)}
+                          onChange={() => toggleField(f)}
+                          className="h-4 w-4 rounded border-gray-300"
+                        />
+                        <span>{f}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <label className="text-sm font-medium">Format</label>
+                  <div className="mt-2 space-y-1">
+                    {Object.values(PersonOutputFormat).map((v) => (
+                      <label key={v} className="flex items-center space-x-2 text-sm">
+                        <input
+                          type="radio"
+                          name="format"
+                          value={v}
+                          checked={format === v}
+                          onChange={() => setFormat(v)}
+                          className="h-4 w-4"
+                        />
+                        <span className="uppercase">{v}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {format === PersonOutputFormat.CUSTOM && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setShowTemplate(true)}
+                    className="mt-2 flex items-center gap-1 h-8"
+                  >
+                    <Pencil className="h-3 w-3" /> Edit Template
+                  </Button>
+                )}
+
+                <Button onClick={handleGenerate} className="w-full mt-4">
+                  Generate
+                </Button>
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label className="text-sm font-medium">Output</label>
+                  {output && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="flex items-center gap-1 h-7 px-2 text-xs"
+                      onClick={handleCopy}
+                    >
+                      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                      {copied ? "Copied" : "Copy"}
+                    </Button>
+                  )}
+                </div>
+                {error ? (
+                  <Alert variant="destructive">
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                ) : (
+                  <Textarea
+                    className="min-h-[300px] font-mono"
+                    value={output}
+                    readOnly
+                    placeholder="Generated data will appear here"
+                  />
+                )}
+                {output && (
+                  <Button onClick={handleSave} className="w-full mt-4 flex items-center gap-1" variant="outline">
+                    <FileDown className="h-4 w-4" /> Save as File
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Modal
+        open={showTemplate}
+        title="Edit Template"
+        onCancel={() => setShowTemplate(false)}
+        onOk={saveTemplate}
+        okText="Save"
+        cancelText="Cancel"
+      >
+        <p className="text-sm mb-2">
+          Available variables: {ALL_FIELDS.map((f) => `{{${f}}}`).join(", ")}
+        </p>
+        <Textarea
+          value={template}
+          onChange={(e) => setTemplate(e.target.value)}
+          className="font-mono min-h-[150px]"
+        />
+        <div className="flex justify-end mt-2">
+          <Button variant="outline" size="sm" onClick={resetTemplate}>
+            Reset
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}
+
+export default PersonGenerator;

--- a/desktop/test/person-generator.spec.ts
+++ b/desktop/test/person-generator.spec.ts
@@ -55,7 +55,7 @@ describe('Person Generator tests', async () => {
 
     await (await findButtonByText(page, 'Generate'))?.click()
 
-    await waitForTextareaOutput(page, { notEmpty: true })
+    await waitForTextareaOutput(page, { notEmpty: true, index: 0 })
 
     await takeScreenshot(page, 'person-generator', 'generated', true)
   })

--- a/desktop/test/person-generator.spec.ts
+++ b/desktop/test/person-generator.spec.ts
@@ -1,0 +1,62 @@
+import * as path from 'node:path'
+import { type ElectronApplication, type Page, type JSHandle } from 'playwright'
+import type { BrowserWindow } from 'electron'
+import { beforeAll, afterAll, describe, expect, test } from 'vitest'
+import {
+  launchElectronWithRetry,
+  findButtonByText,
+  takeScreenshot,
+  navigateToTool,
+  waitForTextareaOutput,
+} from './utils'
+
+const root = path.join(__dirname, '..')
+let electronApp: ElectronApplication | null = null
+let page: Page | null = null
+
+const TOOL_BUTTON_NAME = 'Person Generator'
+const COMPONENT_TITLE = 'Person Generator'
+const isCI = process.env.CI === 'true'
+
+describe('Person Generator tests', async () => {
+  beforeAll(async () => {
+    try {
+      electronApp = await launchElectronWithRetry()
+      page = await electronApp.firstWindow()
+      const loadTimeout = isCI ? 30000 : 10000
+      await page.waitForLoadState('domcontentloaded', { timeout: loadTimeout })
+      const mainWin: JSHandle<BrowserWindow> = await electronApp.browserWindow(page)
+      await mainWin.evaluate(async (win) => {
+        win.webContents.executeJavaScript('// Test initialization complete')
+      })
+    } catch (error) {
+      console.error('Setup failed:', error)
+      throw error
+    }
+  })
+
+  afterAll(async () => {
+    if (page) {
+      await page.close().catch(err => console.error('Error closing page:', err))
+    }
+    if (electronApp) {
+      await electronApp.close().catch(err => console.error('Error closing app:', err))
+    }
+  })
+
+  test('should generate people data', async () => {
+    expect(page).not.toBeNull()
+    if (!page) return
+
+    await navigateToTool(page, TOOL_BUTTON_NAME, COMPONENT_TITLE)
+
+    const countInput = page.locator('input#count')
+    await countInput.fill('2')
+
+    await (await findButtonByText(page, 'Generate'))?.click()
+
+    await waitForTextareaOutput(page, { notEmpty: true })
+
+    await takeScreenshot(page, 'person-generator', 'generated', true)
+  })
+})

--- a/desktop/test/utils.ts
+++ b/desktop/test/utils.ts
@@ -231,6 +231,8 @@ export interface WaitForOutputOptions {
   hasLineBreaks?: boolean;
   /** Maximum time to wait in milliseconds */
   timeout?: number;
+  /** Index of the textarea to check (default: 1 for output) */
+  index?: number;
 }
 
 /**
@@ -305,6 +307,7 @@ export async function waitForTextareaOutput(page: Page, options: WaitForOutputOp
   
   // Set default timeout based on CI environment
   const timeout = options.timeout || (process.env.CI === 'true' ? 10000 : 2000);
+  const index = options.index ?? 1;
   
   try {
     // Create a condition function based on the provided options
@@ -313,8 +316,9 @@ export async function waitForTextareaOutput(page: Page, options: WaitForOutputOp
 
       if (textareas.length === 0) return false;
 
-      // Use the last textarea on the page as output
-      const outputTextarea = textareas[textareas.length - 1];
+      // Determine which textarea to use as output
+      const outIdx = opts.index ?? textareas.length - 1;
+      const outputTextarea = textareas[outIdx];
       const outputValue = outputTextarea.value;
       
       // If no output yet, condition is not met
@@ -328,10 +332,10 @@ export async function waitForTextareaOutput(page: Page, options: WaitForOutputOp
       
       // All checks passed
       return true;
-    }, options, { timeout });
-    
+    }, { ...options, index }, { timeout });
+
     // Return the output text
-    return await getTextareaOutput(page);
+    return await getTextareaOutput(page, index);
   } catch (error) {
     console.error('Error waiting for textarea output:', error);
     throw new Error(`Timed out waiting for textarea output: ${JSON.stringify(options)}`);


### PR DESCRIPTION
## Summary
- add Person Generator component in desktop app using shared logic
- include person generator in desktop tool list
- add e2e test for the person generator

## Testing
- `pnpm lint` *(landing)*
- `pnpm types:check` *(landing)*
- `pnpm lint` *(shared)*
- `pnpm types:check` *(shared)*
- `pnpm types:check` *(desktop)*
- `pnpm test:no-screen` *(fails: Failed to launch Electron)*

------
https://chatgpt.com/codex/tasks/task_e_684b0232b15883259f8f9c7458d5d430