### PR TITLE
fix: use consistent icons for app window and tray

### DIFF
--- a/desktop/electron/main/index.ts
+++ b/desktop/electron/main/index.ts
@@ -111,7 +111,7 @@ function setupClipboardHandlers() {
 async function createWindow() {
   win = new BrowserWindow({
     title: 'Main window',
-    icon: path.join(process.env.VITE_PUBLIC, 'favicon.ico'),
+    icon: path.join(process.env.APP_ROOT, 'resources', 'icons', 'icon_256x256.png'),
     width: 1270,
     height: 640,
     webPreferences: {
@@ -154,7 +154,7 @@ async function createWindow() {
  */
 function createTray() {
   // Use a fallback icon if the favicon.ico is not found
-  let iconPath = path.join(process.env.VITE_PUBLIC, 'favicon.ico')
+  let iconPath = path.join(process.env.APP_ROOT, 'resources', 'icons', 'icon_256x256.png')
   let trayIcon;
   
   // Fallback to app.getAppPath() if the icon doesn't exist


### PR DESCRIPTION
The main application window and the system tray icon were previously using `favicon.ico` from the public directory, while the packaged application icon was being sourced from `resources/icons/`.

This change updates `desktop/electron/main/index.ts` to use `resources/icons/icon_256x256.png` for both the `createWindow` and `createTray` functions. This ensures that the icons used during runtime (window icon, tray icon) are consistent with the icon defined in `electron-builder.json` for the packaged application.