### PR TITLE
Fix layout on Updates tab

### DIFF
--- a/desktop/src/components/updates-page.tsx
+++ b/desktop/src/components/updates-page.tsx
@@ -133,8 +133,10 @@ export function UpdatesPage({ className = "" }: UpdatesPageProps) {
             {`Update to v${updateInfo.latest}`}
           </Button>
         )}
-        <span className="ml-auto text-sm">{logs[logs.length - 1] ?? 'Idle'}</span>
-        <Button variant="ghost" size="sm" onClick={() => setShowLogs(v => !v)}>
+      </div>
+      <div className="mb-4 flex items-center gap-2 flex-wrap">
+        <span className="text-sm">{logs[logs.length - 1] ?? 'Idle'}</span>
+        <Button className="ml-auto" variant="ghost" size="sm" onClick={() => setShowLogs(v => !v)}>
           {showLogs ? 'Hide Logs' : 'Show Logs'}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- adjust the layout of the Updates tab so the log status and "Show Logs" button appear below the update buttons

## Testing
- `pnpm -r lint && pnpm -r types:check && pnpm -r test` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_684c0280d8b8832583df449c97ed741d