### PR TITLE
Fix: Update UI text on Updates page

### DIFF
--- a/desktop/src/components/updates-page.tsx
+++ b/desktop/src/components/updates-page.tsx
@@ -54,7 +54,7 @@ export function UpdatesPage({ className = "" }: UpdatesPageProps) {
       const latest = (data.tag_name || data.name || '').replace(/^v/, '');
 
       if (latest && compareVersions(latest, current) > 0) {
-        log(`Update available: v${latest}`);
+        log(`Yes, an update is available: v${latest}`);
         let foundAsset = null;
         if (data.assets && Array.isArray(data.assets)) {
           for (const asset of data.assets) {
@@ -89,7 +89,7 @@ export function UpdatesPage({ className = "" }: UpdatesPageProps) {
           log(`Update v${latest} is available, but no suitable download found for your platform (${platform}) and architecture (${arch}).`);
         }
       } else {
-        log(`Current version v${current} is up-to-date or newer than latest release (${latest}).`);
+        log(`No, an update is not available. Current version v${current} is up-to-date or newer than the latest release (${latest}).`);
       }
     } catch (e: any) {
       log(`Error: ${e.message}`);
@@ -135,7 +135,10 @@ export function UpdatesPage({ className = "" }: UpdatesPageProps) {
         )}
       </div>
       <div className="mb-4 flex items-center gap-2 flex-wrap">
-        <span className="text-sm">{logs[logs.length - 1] ?? 'Idle'}</span>
+        <span className="text-sm">
+          {logs[logs.length - 1] ??
+            'Click "Check for Updates" to get the latest information.'}
+        </span>
         <Button className="ml-auto" variant="ghost" size="sm" onClick={() => setShowLogs(v => !v)}>
           {showLogs ? 'Hide Logs' : 'Show Logs'}
         </Button>


### PR DESCRIPTION
This commit addresses two issues on the Updates page:

1.  The "Idle" status message before checking for updates was unclear. I have changed it to "Click "Check for Updates" to get the latest information."
2.  The update status messages were not explicit enough. They now clearly state whether an update is available or not:
    - "Yes, an update is available: vX.Y.Z"
    - "No, an update is not available. Current version vA.B.C is up-to-date or newer than the latest release (D.E.F)."

These changes improve the clarity and user-friendliness of the update process in your desktop application.