### PR TITLE
Add Image Resizer tool

### DIFF
--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -24,11 +24,12 @@ import {
   FaShieldAlt, 
   FaHashtag, 
   FaFileAlt, 
-  FaUser, 
-  FaFingerprint, 
-  FaClock, 
-  FaSlash, 
-  FaRulerCombined 
+  FaUser,
+  FaFingerprint,
+  FaClock,
+  FaSlash,
+  FaRulerCombined,
+  FaImage
 } from 'react-icons/fa';
 
 const getToolIcon = (title: string) => {
@@ -42,6 +43,7 @@ const getToolIcon = (title: string) => {
     "File & Text Hash Compare": <FaShieldAlt />,
     "Text Hash Generator": <FaHashtag />,
     "File Generator": <FaFileAlt />,
+    "Image Resizer": <FaImage />,
     "Person Generator": <FaUser />,
     "UUID Generator": <FaFingerprint />,
     "Speech Length Estimator": <FaClock />,

--- a/landing/app/tools/image-resizer/ImageResizer.tsx
+++ b/landing/app/tools/image-resizer/ImageResizer.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Container } from "@/components/ui/container";
+import { SectionHeading } from "@/components/ui/section";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useState } from "react";
+import { Check, Copy, Download, Link as LinkIcon, AlertCircle } from "lucide-react";
+import Link from "next/link";
+import { resizeImage, ImageResizeOptions, DEFAULT_IMAGE_RESIZE_OPTIONS } from "shared";
+
+export default function ImageResizer() {
+  const [file, setFile] = useState<File | null>(null);
+  const [width, setWidth] = useState<string>("100");
+  const [height, setHeight] = useState<string>("100");
+  const [keepAspect, setKeepAspect] = useState(true);
+  const [outputUrl, setOutputUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleResize = async () => {
+    if (!file) return;
+    try {
+      const options: ImageResizeOptions = {
+        width: parseInt(width, 10) || DEFAULT_IMAGE_RESIZE_OPTIONS.width,
+        height: parseInt(height, 10) || DEFAULT_IMAGE_RESIZE_OPTIONS.height,
+        keepAspectRatio: keepAspect,
+        type: DEFAULT_IMAGE_RESIZE_OPTIONS.type,
+        quality: DEFAULT_IMAGE_RESIZE_OPTIONS.quality,
+      };
+      const blob = await resizeImage(file, options);
+      const url = URL.createObjectURL(blob);
+      if (outputUrl) URL.revokeObjectURL(outputUrl);
+      setOutputUrl(url);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+      setOutputUrl(null);
+    }
+  };
+
+  const handleCopy = () => {
+    if (!outputUrl) return;
+    navigator.clipboard.writeText(outputUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownload = () => {
+    if (!outputUrl) return;
+    const a = document.createElement("a");
+    a.href = outputUrl;
+    a.download = "resized-image";
+    a.click();
+  };
+
+  return (
+    <>
+      <Container className="py-8 md:py-12">
+        <SectionHeading
+          title="Image Resizer"
+          description="Resize images to custom dimensions directly in your browser."
+        />
+        <div className="mb-4 flex items-center text-sm text-muted-foreground gap-2">
+          <LinkIcon className="h-4 w-4" />
+          <span>Related tool: </span>
+          <Link href="/tools/file-generator" className="text-primary hover:underline">
+            File Generator
+          </Link>
+        </div>
+        <div className="space-y-4">
+          <div className="flex flex-wrap md:flex-nowrap gap-8">
+            <div className="w-full md:w-1/2 space-y-2">
+              <Label htmlFor="image-file">Select Image</Label>
+              <Input id="image-file" type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+              <div className="flex gap-2">
+                <div className="flex flex-col">
+                  <Label htmlFor="width">Width</Label>
+                  <Input id="width" type="number" value={width} onChange={(e) => setWidth(e.target.value)} />
+                </div>
+                <div className="flex flex-col">
+                  <Label htmlFor="height">Height</Label>
+                  <Input id="height" type="number" value={height} onChange={(e) => setHeight(e.target.value)} />
+                </div>
+                <div className="flex items-end pb-1">
+                  <label className="flex items-center gap-2 text-sm">
+                    <input type="checkbox" checked={keepAspect} onChange={(e) => setKeepAspect(e.target.checked)} />
+                    Keep aspect
+                  </label>
+                </div>
+              </div>
+              <Button onClick={handleResize} className="w-full">Resize Image</Button>
+            </div>
+            <div className="w-full md:w-1/2 flex flex-col items-center justify-center">
+              {error ? (
+                <Alert variant="destructive" className="w-full">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertTitle>Error</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              ) : outputUrl ? (
+                <img src={outputUrl} alt="Resized" className="max-w-full max-h-80 object-contain" />
+              ) : (
+                <div className="text-muted-foreground">No image resized yet.</div>
+              )}
+              {outputUrl && (
+                <div className="mt-2 flex gap-2">
+                  <Button size="sm" variant="outline" onClick={handleCopy} className="flex items-center gap-1">
+                    {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    {copied ? "Copied!" : "Copy URL"}
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={handleDownload} className="flex items-center gap-1">
+                    <Download className="h-4 w-4" /> Download
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </Container>
+    </>
+  );
+}

--- a/landing/app/tools/image-resizer/page.tsx
+++ b/landing/app/tools/image-resizer/page.tsx
@@ -1,0 +1,31 @@
+import ImageResizer from "./ImageResizer";
+import { StructuredData } from "@/components/structured-data";
+import { generateMetadata, toolDescriptions, toolTitles } from "@/lib/metadata";
+
+export const metadata = generateMetadata({
+  title: toolTitles.imageResizer.base,
+  description: toolDescriptions.imageResizer,
+  openGraph: {
+    title: toolTitles.imageResizer.extended,
+    description: toolDescriptions.imageResizer,
+  },
+  twitter: {
+    title: toolTitles.imageResizer.extended,
+    description: toolDescriptions.imageResizer,
+  },
+});
+
+export default function ImageResizerPage() {
+  return (
+    <>
+      <StructuredData
+        type="tool"
+        toolName="Image Resizer"
+        toolDescription="Resize images directly in your browser with optional aspect ratio preservation."
+        toolUrl="/tools/image-resizer"
+        toolCategory="DeveloperTool"
+      />
+      <ImageResizer />
+    </>
+  );
+}

--- a/landing/components/online-tools-grid.tsx
+++ b/landing/components/online-tools-grid.tsx
@@ -52,6 +52,11 @@ export const onlineTools = [
     description: "Generate files with specific size and format with random data, zeros, or custom patterns.",
   },
   {
+    title: "Image Resizer",
+    path: "/tools/image-resizer",
+    description: "Resize images to custom dimensions directly in your browser.",
+  },
+  {
     title: "Person Generator",
     path: "/tools/person-generator",
     description: "Create fake person data with chosen fields in multiple formats.",

--- a/landing/lib/metadata.ts
+++ b/landing/lib/metadata.ts
@@ -47,6 +47,10 @@ export const toolTitles = {
     base: "UUID Generator",
     extended: "UUID Generator - Create RFC4122 Compliant UUIDs",
   },
+  imageResizer: {
+    base: "Image Resizer",
+    extended: "Image Resizer - Resize Images Offline in Your Browser",
+  },
 };
 
 /**
@@ -163,6 +167,9 @@ export const toolDescriptions = {
 
   uuidGenerator:
     "Generate universally unique identifiers (UUIDs) in various formats (v1, v4, v5, v6, v7). Create, validate, and format UUIDs with complete privacy.",
+
+  imageResizer:
+    "Resize images to custom dimensions directly in your browser while keeping data private and offline.",
 
   common:
     "Process data securely in your browser without server transmission. Works offline with our desktop app for complete privacy and security.",

--- a/shared/src/image-resizer/index.test.ts
+++ b/shared/src/image-resizer/index.test.ts
@@ -1,0 +1,47 @@
+import { resizeImage, DEFAULT_IMAGE_RESIZE_OPTIONS } from './index';
+
+async function loadSharp(): Promise<unknown> {
+  try {
+    // @ts-ignore - optional dependency
+    return (await import('sharp')).default;
+  } catch {
+    const path = require('node:path');
+    const modPath = path.join(__dirname, '../../../node_modules/.pnpm/sharp@0.34.1/node_modules/sharp/lib/index.js');
+    // @ts-ignore - optional dependency
+    return (await import(modPath)).default;
+  }
+}
+
+describe('resizeImage', () => {
+  const createSampleBlob = async (): Promise<Blob> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sharp = (await loadSharp()) as any;
+    const buf = await sharp({ create: { width: 4, height: 4, channels: 3, background: { r: 255, g: 0, b: 0 } } }).png().toBuffer();
+    return new Blob([buf], { type: 'image/png' });
+  };
+
+  it('should resize image with aspect ratio', async () => {
+    const blob = await createSampleBlob();
+    const out = await resizeImage(blob, { ...DEFAULT_IMAGE_RESIZE_OPTIONS, width: 2, height: 2 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sharp = (await loadSharp()) as any;
+    const meta = await sharp(Buffer.from(await out.arrayBuffer())).metadata();
+    expect(meta.width).toBe(2);
+    expect(meta.height).toBe(2);
+  });
+
+  it('should resize without keeping aspect ratio', async () => {
+    const blob = await createSampleBlob();
+    const out = await resizeImage(blob, { ...DEFAULT_IMAGE_RESIZE_OPTIONS, width: 3, height: 1, keepAspectRatio: false });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sharp = (await loadSharp()) as any;
+    const meta = await sharp(Buffer.from(await out.arrayBuffer())).metadata();
+    expect(meta.width).toBe(3);
+    expect(meta.height).toBe(1);
+  });
+
+  it('should throw error for empty input', async () => {
+    const empty = new Blob([]);
+    await expect(resizeImage(empty)).rejects.toThrow('Input image is empty');
+  });
+});

--- a/shared/src/image-resizer/index.ts
+++ b/shared/src/image-resizer/index.ts
@@ -1,0 +1,133 @@
+/**
+ * Options for image resizing
+ */
+export interface ImageResizeOptions {
+  /** Desired width of output image */
+  width: number;
+  /** Desired height of output image */
+  height: number;
+  /** Preserve aspect ratio */
+  keepAspectRatio: boolean;
+  /** Output MIME type */
+  type: 'image/png' | 'image/jpeg' | 'image/webp';
+  /** Quality from 0 to 1 for JPEG/WebP */
+  quality?: number;
+}
+
+/**
+ * Default image resize options
+ */
+export const DEFAULT_IMAGE_RESIZE_OPTIONS: ImageResizeOptions = {
+  width: 100,
+  height: 100,
+  keepAspectRatio: true,
+  type: 'image/png',
+  quality: 0.92,
+};
+
+/**
+ * Attempts to dynamically load the sharp library from pnpm path
+ * @returns Sharp module or throws if not found
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function loadSharp(): Promise<any> {
+  try {
+    // @ts-ignore - optional dependency may not have types
+    const mod = await import('sharp');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (mod as any).default || mod;
+  } catch {
+    const path = require('node:path');
+    const modPath = path.join(
+      __dirname,
+      '../../../node_modules/.pnpm/sharp@0.34.1/node_modules/sharp/lib/index.js'
+    );
+    // @ts-ignore - optional dependency may not have types
+    const mod = await import(modPath);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (mod as any).default || mod;
+  }
+}
+
+/**
+ * Resize an image Blob using either browser canvas or sharp in Node
+ * @param input - Image blob to resize
+ * @param options - Resize options
+ * @returns Promise resolving to resized image blob
+ */
+export async function resizeImage(
+  input: Blob,
+  options: ImageResizeOptions = DEFAULT_IMAGE_RESIZE_OPTIONS
+): Promise<Blob> {
+  try {
+    if (!input || input.size === 0) {
+      throw new Error('Input image is empty');
+    }
+
+    if (typeof window === 'undefined') {
+      const sharp = await loadSharp();
+      const buffer = Buffer.from(await input.arrayBuffer());
+      const fit = options.keepAspectRatio ? 'inside' : 'fill';
+      let pipeline = sharp(buffer).resize(options.width, options.height, { fit });
+
+      if (options.type === 'image/jpeg') {
+        pipeline = pipeline.jpeg({ quality: Math.round((options.quality ?? 0.92) * 100) });
+      } else if (options.type === 'image/webp') {
+        pipeline = pipeline.webp({ quality: Math.round((options.quality ?? 0.92) * 100) });
+      } else {
+        pipeline = pipeline.png();
+      }
+
+      const out = await pipeline.toBuffer();
+      return new Blob([out], { type: options.type });
+    }
+
+    const dataUrl: string = await new Promise((resolve, reject): void => {
+      const reader = new FileReader();
+      reader.onload = (): void => resolve(reader.result as string);
+      reader.onerror = (): void => reject(new Error('Failed to read image'));
+      reader.readAsDataURL(input);
+    });
+
+    const img = await new Promise<HTMLImageElement>((resolve, reject): void => {
+      const image = new Image();
+      image.onload = (): void => resolve(image);
+      image.onerror = (): void => reject(new Error('Failed to load image'));
+      image.src = dataUrl;
+    });
+
+    let targetWidth = options.width;
+    let targetHeight = options.height;
+    if (options.keepAspectRatio) {
+      const ratio = img.width / img.height;
+      if (targetWidth / targetHeight > ratio) {
+        targetWidth = Math.round(targetHeight * ratio);
+      } else {
+        targetHeight = Math.round(targetWidth / ratio);
+      }
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas context is null');
+    ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+    return await new Promise<Blob>((resolve, reject): void => {
+      canvas.toBlob(
+        (blob): void => {
+          if (!blob) {
+            reject(new Error('Canvas conversion failed'));
+          } else {
+            resolve(blob);
+          }
+        },
+        options.type,
+        options.quality
+      );
+    });
+  } catch (error) {
+    throw new Error(`Image resizing failed: ${(error as Error).message}`);
+  }
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -95,6 +95,9 @@ export * from './text-utility/clipboard-registration';
 // Export Unit Converter
 export * from './unit-converter';
 
+// Export Image Resizer
+export * from './image-resizer';
+
 // Export Text Utility
 export * from './text-utility';
 


### PR DESCRIPTION
## Summary
- implement `resizeImage` shared library
- create Image Resizer page and UI
- list Image Resizer in tool metadata and grids
- map Image Resizer icon in homepage
- add tests for new shared feature

## Testing
- `cd shared && pnpm lint && pnpm types:check && pnpm test`
- `cd landing && pnpm lint && pnpm types:check`

------
https://chatgpt.com/codex/tasks/task_e_684c2c81bf008325942b95c7b2930da5