### PR TITLE
Fix AlertTitle import for QR Code tool

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -9,7 +9,8 @@ import {
   Users,
   RefreshCw,
   ShieldCheck,
-  Type
+  Type,
+  QrCode
 } from 'lucide-react'
 import { Sidebar, Tool } from './components/sidebar'
 import { JsonFormatter } from './components/json-formatter'
@@ -27,6 +28,7 @@ import UpdatesPage from './components/updates-page'
 import { PersonGenerator } from './components/person-generator'
 import { PasswordStrengthMeter } from './components/password-strength-meter'
 import { TextUtility } from './components/text-utility'
+import { QrCodeTool } from './components/qr-code'
 
 // List of tools
 const tools: Tool[] = [
@@ -40,6 +42,7 @@ const tools: Tool[] = [
   { id: 'ethereum-converter', name: 'Ethereum Converter', icon: <Hash size={16} /> },
   { id: 'unit-converter', name: 'Unit Converter', icon: <Hash size={16} /> },
   { id: 'text-utility', name: 'Text Utility', icon: <Type size={16} /> },
+  { id: 'qr-code', name: 'QR Code Tool', icon: <QrCode size={16} /> },
   { id: 'password-strength-meter', name: 'Password Strength Meter', icon: <ShieldCheck size={16} /> },
   { id: 'updates', name: 'Updates', icon: <RefreshCw size={16} /> },
 ]
@@ -146,6 +149,8 @@ function App() {
           <UnitConverter className="min-h-full" />
         ) : selectedTool === 'text-utility' ? (
           <TextUtility className="min-h-full" />
+        ) : selectedTool === 'qr-code' ? (
+          <QrCodeTool className="min-h-full" />
         ) : selectedTool === 'password-strength-meter' ? (
           <PasswordStrengthMeter className="min-h-full" />
         ) : selectedTool === 'updates' ? (

--- a/desktop/src/components/qr-code.tsx
+++ b/desktop/src/components/qr-code.tsx
@@ -1,0 +1,199 @@
+import { useState, useRef } from "react";
+import { Download, AlertCircle, Check, Copy, HelpCircle } from "lucide-react";
+import { generateQrCode, decodeQrCode, QrCodeOptions } from "shared/qr-code";
+import { Button } from "./ui/button";
+import { Textarea } from "./ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
+
+interface QrCodeToolProps {
+  className?: string;
+}
+
+export function QrCodeTool({ className = "" }: QrCodeToolProps) {
+  const [mode, setMode] = useState<"generate" | "decode">("generate");
+  const [textInput, setTextInput] = useState("");
+  const [size, setSize] = useState(256);
+  const [errorCorrection, setErrorCorrection] = useState<QrCodeOptions["errorCorrectionLevel"]>("M");
+  const [qrDataUrl, setQrDataUrl] = useState("");
+  const [decodeResult, setDecodeResult] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleGenerate = async () => {
+    try {
+      const opts: Partial<QrCodeOptions> = {
+        width: size,
+        margin: 2,
+        errorCorrectionLevel: errorCorrection,
+      };
+      const url = await generateQrCode(textInput, opts);
+      setQrDataUrl(url);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+      setQrDataUrl("");
+    }
+  };
+
+  const handleDecodeFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = async () => {
+      try {
+        const result = await decodeQrCode(reader.result as string);
+        setDecodeResult(result);
+        setError(null);
+      } catch (e) {
+        setError((e as Error).message);
+        setDecodeResult("");
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleDecodeFile(file);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(decodeResult);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDownload = () => {
+    const a = document.createElement("a");
+    a.href = qrDataUrl;
+    a.download = "qr-code.png";
+    a.click();
+  };
+
+  const handleTabChange = (value: string) => {
+    setMode(value as "generate" | "decode");
+    setTextInput("");
+    setQrDataUrl("");
+    setDecodeResult("");
+    setError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  return (
+    <div className={`p-4 h-full flex flex-col ${className}`}>
+      <Card className="flex-1 flex flex-col">
+        <CardHeader className="pb-3">
+          <CardTitle>QR Code Tool</CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 flex flex-col">
+          <div className="space-y-4 flex-1 flex flex-col">
+            <Tabs value={mode} onValueChange={handleTabChange} className="w-auto">
+              <TabsList className="grid grid-cols-2 w-[200px]">
+                <TabsTrigger value="generate">Generate</TabsTrigger>
+                <TabsTrigger value="decode">Decode</TabsTrigger>
+              </TabsList>
+            </Tabs>
+            {mode === "generate" ? (
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="qr-input" className="block mb-1 text-sm font-medium">Text / URL</label>
+                  <Textarea
+                    id="qr-input"
+                    className="w-full"
+                    value={textInput}
+                    onChange={(e) => setTextInput(e.target.value)}
+                    placeholder="Enter text to encode"
+                  />
+                </div>
+                <div className="flex flex-wrap gap-4 items-end">
+                  <div>
+                    <label htmlFor="size" className="block mb-1 text-sm font-medium">Size (px)</label>
+                    <input
+                      id="size"
+                      type="number"
+                      min={64}
+                      max={1024}
+                      value={size}
+                      onChange={(e) => setSize(Number(e.target.value))}
+                      className="w-24 border rounded h-8 px-2 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-1 mb-1 text-sm font-medium">
+                      <label>Error Correction</label>
+                      <span
+                        title="Higher levels keep data readable even if the QR code is partially damaged"
+                        className="inline-flex cursor-help text-muted-foreground"
+                      >
+                        <HelpCircle className="h-4 w-4 pointer-events-none" />
+                      </span>
+                    </div>
+                    <div className="flex gap-2">
+                      {['L','M','Q','H'].map(level => (
+                        <label key={level} className="flex items-center gap-1">
+                          <input
+                            type="radio"
+                            name="error-correction"
+                            value={level}
+                            checked={errorCorrection === level}
+                            onChange={(e) => setErrorCorrection(e.target.value as QrCodeOptions["errorCorrectionLevel"])}
+                            className="h-4 w-4"
+                          />
+                          <span>{level}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <Button onClick={handleGenerate} className="w-full">Generate QR Code</Button>
+                {error && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Error</AlertTitle>
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                )}
+                {qrDataUrl && (
+                  <div className="flex flex-col items-center gap-2">
+                    {/* eslint-disable-next-line jsx-a11y/alt-text */}
+                    <img src={qrDataUrl} width={size} height={size} />
+                    <Button size="sm" variant="outline" className="flex items-center gap-1" onClick={handleDownload}>
+                      <Download className="h-4 w-4" />
+                      Download
+                    </Button>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <input type="file" accept="image/*" ref={fileInputRef} onChange={handleFileChange} />
+                {decodeResult && (
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <label htmlFor="decode-output" className="block mb-1 text-sm font-medium">Decoded Text</label>
+                      <Button size="sm" variant="outline" className="flex items-center gap-1" onClick={handleCopy}>
+                        {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                        {copied ? "Copied!" : "Copy"}
+                      </Button>
+                    </div>
+                    <Textarea id="decode-output" className="w-full h-32" value={decodeResult} readOnly />
+                  </div>
+                )}
+                {error && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Error</AlertTitle>
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                )}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default QrCodeTool;

--- a/desktop/src/components/ui/alert.tsx
+++ b/desktop/src/components/ui/alert.tsx
@@ -15,6 +15,11 @@ interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
 interface AlertDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 /**
+ * Alert title component props
+ */
+interface AlertTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+/**
  * Alert component
  * @param props - Alert component props
  * @returns Alert component
@@ -67,4 +72,21 @@ export function AlertDescription({
       {...props}
     />
   );
-} 
+}
+
+/**
+ * Alert title component
+ * @param props - Alert title component props
+ * @returns Alert title component
+ */
+export const AlertTitle = React.forwardRef<HTMLParagraphElement, AlertTitleProps>(
+  ({ className, ...props }, ref) => (
+    <h5
+      ref={ref}
+      className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+);
+
+AlertTitle.displayName = "AlertTitle";

--- a/desktop/test/qr-code.spec.ts
+++ b/desktop/test/qr-code.spec.ts
@@ -1,0 +1,88 @@
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+import { type ElectronApplication, type Page, type JSHandle } from 'playwright'
+import type { BrowserWindow } from 'electron'
+import { beforeAll, afterAll, describe, expect, test } from 'vitest'
+import {
+  launchElectronWithRetry,
+  findButtonByText,
+  takeScreenshot,
+  navigateToTool,
+  waitForComponentTitle
+} from './utils'
+import { generateQrCode } from '../../shared/src/qr-code'
+
+const root = path.join(__dirname, '..')
+let electronApp: ElectronApplication | null = null
+let page: Page | null = null
+
+const TOOL_BUTTON_NAME = 'QR Code Tool'
+const COMPONENT_TITLE = 'QR Code Tool'
+const isCI = process.env.CI === 'true'
+
+async function createTempQrFile(text: string): Promise<string> {
+  const dataUrl = await generateQrCode(text)
+  const base64 = dataUrl.replace(/^data:image\/png;base64,/, '')
+  const buffer = Buffer.from(base64, 'base64')
+  const tmpPath = path.join(root, 'test-qr.png')
+  fs.writeFileSync(tmpPath, buffer)
+  return tmpPath
+}
+
+describe('QR Code Tool tests', async () => {
+  beforeAll(async () => {
+    electronApp = await launchElectronWithRetry()
+    page = await electronApp.firstWindow()
+    const loadTimeout = isCI ? 30000 : 10000
+    await page.waitForLoadState('domcontentloaded', { timeout: loadTimeout })
+    const mainWin: JSHandle<BrowserWindow> = await electronApp.browserWindow(page)
+    await mainWin.evaluate(async (win) => {
+      win.webContents.executeJavaScript('// Test initialization complete')
+    })
+  })
+
+  afterAll(async () => {
+    if (page) {
+      await page.close().catch(err => console.error('Error closing page:', err))
+    }
+    if (electronApp) {
+      await electronApp.close().catch(err => console.error('Error closing app:', err))
+    }
+    const tmp = path.join(root, 'test-qr.png')
+    if (fs.existsSync(tmp)) fs.unlinkSync(tmp)
+  })
+
+  test('should generate QR code from text', async () => {
+    expect(page).not.toBeNull()
+
+    await navigateToTool(page!, TOOL_BUTTON_NAME, COMPONENT_TITLE)
+
+    await takeScreenshot(page!, 'qr-code', 'initial-view')
+
+    await page!.fill('textarea', 'Hello QR')
+
+    await (await findButtonByText(page!, 'Generate QR Code'))!.click()
+
+    await page!.waitForSelector('img', { state: 'visible', timeout: isCI ? 10000 : 3000 })
+
+    await takeScreenshot(page!, 'qr-code', 'after-generate', true)
+  })
+
+  test('should decode QR code image', async () => {
+    expect(page).not.toBeNull()
+
+    await navigateToTool(page!, TOOL_BUTTON_NAME, COMPONENT_TITLE)
+
+    await (await findButtonByText(page!, 'Decode'))!.click()
+
+    const tmpFile = await createTempQrFile('Decode Test')
+    const fileInput = await page!.$('input[type="file"]')
+    await fileInput!.setInputFiles(tmpFile)
+
+    await page!.waitForSelector('textarea#decode-output', { state: 'visible', timeout: isCI ? 10000 : 3000 })
+
+    await expect(page!.$eval('#decode-output', el => (el as HTMLTextAreaElement).value)).resolves.toContain('Decode Test')
+
+    await takeScreenshot(page!, 'qr-code', 'after-decode', true)
+  })
+})


### PR DESCRIPTION
## Summary
- add `AlertTitle` component to desktop UI components
- register the QR Code tool in the desktop sidebar
- implement QR Code generation/decoding tool and tests
- fix test import path for shared QR Code module

## Testing
- `pnpm -r run lint`
- `pnpm -r run types:check`
- `pnpm --filter "./desktop" run test:no-screen` *(fails: Failed to launch Electron)*

------
https://chatgpt.com/codex/tasks/task_e_684c374ffd1483258010ebce39d6a199