### PR TITLE
Disable automatic update checks

### DIFF
--- a/desktop/electron/main/index.ts
+++ b/desktop/electron/main/index.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import os from 'node:os'
-import { update, startAutoUpdateChecker, stopAutoUpdateChecker } from './update'
+import { update, stopAutoUpdateChecker } from './update'
 
 const require = createRequire(import.meta.url)
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -146,7 +146,7 @@ async function createWindow() {
 
   // Auto update
   update(win)
-  startAutoUpdateChecker(win)
+
 }
 
 /**


### PR DESCRIPTION
## Summary
- stop launching the auto-update checker on startup

## Testing
- `pnpm -r test` *(fails: electron failed to launch)*

------
https://chatgpt.com/codex/tasks/task_e_68554d3477a0832583d3d38bcf8170b2